### PR TITLE
Calculation targets at the prediction grid

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: beethoven
 Title: Building an Extensible, rEproducible, Test-driven, Harmonized, Open-source, Versioned, ENsemble model for air quality
-Version: 0.4.7
+Version: 0.5.0
 Authors@R: c(
     person("Kyle", "Messier", , "kyle.messier@nih.gov", role = c("aut", "cre"), comment = c(ORCID = "0000-0001-9508-9623")),
     person("Mitchell", "Manware", role = c("aut", "ctb"), comment = c(ORCID = "0009-0003-6440-6106")),
@@ -47,7 +47,8 @@ Imports:
   purrr,
   finetune,
   butcher,
-  amadeus
+  amadeus,
+  parquet
 Suggests:
   testthat (>= 3.0.0),
   covr,

--- a/R/calculate.R
+++ b/R/calculate.R
@@ -1,3 +1,4 @@
+
 #' Process atmospheric composition data by chunks
 #' @keywords Calculation
 #' @description
@@ -25,13 +26,11 @@
 #' @importFrom dplyr full_join
 #' @export
 calc_geos_strict <-
-  function(
-    path = NULL,
-    date = c("2018-01-01", "2018-01-01"),
-    locs = NULL,
-    locs_id = NULL,
-    ...
-  ) {
+  function(path = NULL,
+           date = c("2018-01-01", "2018-01-01"),
+           locs = NULL,
+           locs_id = NULL,
+           ...) {
     #### directory setup
     if (length(path) == 1) {
       if (dir.exists(path)) {
@@ -39,7 +38,8 @@ calc_geos_strict <-
         paths <- list.files(
           path,
           pattern = "GEOS-CF.v01.rpl",
-          full.names = TRUE
+          full.names = TRUE,
+          recursive = TRUE
         )
         paths <- paths[grep(
           ".nc4",
@@ -50,7 +50,6 @@ calc_geos_strict <-
       paths <- path
     }
     #### check for variable
-    # amadeus::check_for_null_parameters(mget(ls()))
     #### identify file paths
     #### identify dates based on user input
     dates_of_interest <- amadeus::generate_date_sequence(
@@ -91,8 +90,7 @@ calc_geos_strict <-
     cat(
       paste0(
         "Identified collection ",
-        collection,
-        ".\n"
+        collection
       )
     )
     if (length(collection) > 1) {
@@ -100,7 +98,7 @@ calc_geos_strict <-
         paste0(
           "Multiple collections detected. Ensure that data files ",
           "for each collection are stored in different directories ",
-          "(ie. 'chm' in 'data/chm/' and 'aqc' in 'data/aqc/').\n"
+          "(ie. 'chm' in 'data/chm/' and 'aqc' in 'data/aqc/')."
         )
       )
       # mm-tests-0816 return error for multiple collections in one path
@@ -135,64 +133,21 @@ calc_geos_strict <-
 
     search_variables <-
       if (grepl("chm", collection)) {
-        c(
-          "ACET",
-          "ALD2",
-          "ALK4",
-          "BCPI",
-          "BCPO",
-          "BENZ",
-          "C2H6",
-          "C3H8",
-          "CH4",
-          "CO",
-          "DST1",
-          "DST2",
-          "DST3",
-          "DST4",
-          "EOH",
-          "H2O2",
-          "HCHO",
-          "HNO3",
-          "HNO4",
-          "ISOP",
-          "MACR",
-          "MEK",
-          "MVK",
-          "N2O5",
-          "NH3",
-          "NH4",
-          "NIT",
-          "NO",
-          "NO2",
-          "NOy",
-          "OCPI",
-          "OCPO",
-          "PAN",
-          "PM25_RH35_GCC",
-          "PM25_RH35_GOCART",
-          "PM25bc_RH35_GCC",
-          "PM25du_RH35_GCC",
-          "PM25ni_RH35_GCC",
-          "PM25oc_RH35_GCC",
-          "PM25soa_RH35_GCC",
-          "PM25ss_RH35_GCC",
-          "PM25su_RH35_GCC",
-          "PRPE",
-          "RCHO",
-          "SALA",
-          "SALC",
-          "SO2",
-          "SOAP",
-          "SOAS",
-          "TOLU",
-          "XYLE"
+        c("ACET", "ALD2", "ALK4", "BCPI", "BCPO", "BENZ", "C2H6", "C3H8",
+          "CH4", "CO", "DST1", "DST2", "DST3", "DST4", "EOH", "H2O2",
+          "HCHO", "HNO3", "HNO4", "ISOP", "MACR", "MEK", "MVK", "N2O5",
+          "NH3", "NH4", "NIT", "NO", "NO2", "NOy", "OCPI", "OCPO", "PAN",
+          "PM25_RH35_GCC", "PM25_RH35_GOCART", "PM25bc_RH35_GCC",
+          "PM25du_RH35_GCC", "PM25ni_RH35_GCC", "PM25oc_RH35_GCC",
+          "PM25soa_RH35_GCC", "PM25ss_RH35_GCC", "PM25su_RH35_GCC",
+          "PRPE", "RCHO", "SALA", "SALC", "SO2", "SOAP", "SOAS", "TOLU", "XYLE"
         )
       } else {
         c("CO", "NO2", "O3", "SO2")
       }
 
     # fs is the hourly file paths per day (each element with N=24)
+    # Process by variable in each day
     summary_byvar <- function(x = search_variables, fs) {
       rast_in <- rlang::inject(terra::rast(fs, !!!other_args))
       # strongly assume that we take the single day. no need to filter dates
@@ -203,21 +158,16 @@ calc_geos_strict <-
           x,
           function(v) {
             rast_inidx <- grep(v, data_variables)
-            #rast_in <- mean(rast_in[[rast_inidx]])
+            # Daily mean
             rast_summary <- terra::mean(rast_in[[rast_inidx]])
+
+            # Assign time tag
             rtin <- as.Date(terra::time(rast_in))
             rtin_u <- unique(rtin)
-            cat(sprintf("Processing %s, date: %s\n", v, rtin_u))
-            # rast_summary <- vector("list", length = length(rtin_u))
-            # for (d in seq_along(rtin_u)) {
-            #   rast_d <- rast_in[[rtin == rtin_u[d]]]
-            #   rast_summary[[d]] <- mean(rast_d)
-            # }
-            # rast_summary <- do.call(c, rast_summary)
+            message(sprintf("Processing %s, date: %s", v, rtin_u))
 
-            # the next line is deprecated
-            # rast_summary <- terra::tapp(rast_in, index = "days", fun = "mean")
-            terra::time(rast_summary) <- rtin_u
+            terra::time(rast_summary) <-
+              rep(rtin_u, terra::nlyr(rast_summary))
             names(rast_summary) <-
               paste0(
                 rep(gsub("_lev=.*", "", v), terra::nlyr(rast_summary))
@@ -228,23 +178,21 @@ calc_geos_strict <-
         )
       sds_proc <- terra::sds(sds_proc)
 
+      # SpatVector conversion
       locstr <- terra::vect(locs)
+      # Raster to point extraction
       rast_ext <- terra::extract(sds_proc, locstr, ID = TRUE)
-      # rast_ext <- lapply(rast_ext,
-      #   function(df) {
-      #     df$ID <- unlist(locs[[locs_id]])
-      #     return(df)
-      #   }
-      # )
+
+      # Full join across all variables
       rast_ext <-
-        Reduce(
-          function(dfa, dfb) dplyr::full_join(dfa, dfb, by = "ID"),
+        Reduce(function(dfa, dfb) dplyr::full_join(dfa, dfb, by = "ID"),
           rast_ext
         )
       rast_ext$time <- unique(as.Date(terra::time(rast_in)))
       rast_ext$ID <- unlist(locs[[locs_id]])[rast_ext$ID]
       names(rast_ext)[names(rast_ext) == "ID"] <- locs_id
       return(rast_ext)
+
     }
 
     rast_summary <-
@@ -252,9 +200,11 @@ calc_geos_strict <-
         future_inserted,
         function(fs) summary_byvar(fs = fs)
       )
-    rast_summary <- data.table::rbindlist(rast_summary)
+    # Daily results are rowbound
+    rast_summary <- data.table::rbindlist(rast_summary, fill=TRUE)
 
     return(rast_summary)
+
   }
 
 
@@ -274,15 +224,14 @@ calc_geos_strict <-
 #' @importFrom amadeus download_sanitize_path
 #' @export
 calc_gmted_direct <- function(
-  variable = NULL,
-  path = NULL,
-  locs = NULL,
-  locs_id = NULL,
-  win = c(-126, -62, 22, 52),
-  radius = 0,
-  fun = "mean",
-  ...
-) {
+    variable = NULL,
+    path = NULL,
+    locs = NULL,
+    locs_id = NULL,
+    win = c(-126, -62, 22, 52),
+    radius = 0,
+    fun = "mean",
+    ...) {
   #### directory setup
   path <- amadeus::download_sanitize_path(path)
   #### check for length of variable
@@ -314,22 +263,13 @@ calc_gmted_direct <- function(
     " resolution.\n"
   ))
   statistic_from <- c(
-    "Breakline Emphasis",
-    "Systematic Subsample",
-    "Median Statistic",
-    "Minimum Statistic",
-    "Mean Statistic",
-    "Maximum Statistic",
+    "Breakline Emphasis", "Systematic Subsample",
+    "Median Statistic", "Minimum Statistic",
+    "Mean Statistic", "Maximum Statistic",
     "Standard Deviation Statistic"
   )
   statistic_to <- c(
-    "BRKL",
-    "SSUB",
-    "MEDN",
-    "MINI",
-    "MEAN",
-    "MAXL",
-    "STDV"
+    "BRKL", "SSUB", "MEDN", "MINI", "MEAN", "MAXL", "STDV"
   )
   statistic_to <-
     sprintf("LDU_E%s", statistic_to[match(statistic, statistic_from)])
@@ -352,8 +292,7 @@ calc_gmted_direct <- function(
         statistic_code,
         as.character(resolution_code)
       ),
-      paths,
-      value = TRUE
+      paths, value = TRUE
     )
   # mm-tests-0816 ensures that .prj and .aux.xml files are not read
   # with terra::rast if path points to re-written ASCII file
@@ -407,14 +346,13 @@ calc_gmted_direct <- function(
   colnames(sites_extracted) <- c(
     locs_id,
     paste0(
-      statistic_to,
-      "_",
-      sprintf("%05d", radius)
+      statistic_to, "_", sprintf("%05d", radius)
     )
   )
   #### return data.frame
   return(data.frame(sites_extracted))
 }
+
 
 
 #' Calculate aggregated values for specified locations
@@ -472,11 +410,9 @@ calc_narr2 <- function(
   timetab <- table(time_from)
   if (!all(timetab == 1)) {
     time_split <-
-      split(
-        time_from,
-        #ceiling(seq_along(time_from) / 29L))
-        ceiling(as.integer(as.factor(time_from)) / 14L)
-      )
+      split(time_from,
+            #ceiling(seq_along(time_from) / 29L))
+            ceiling(as.integer(as.factor(time_from)) / 14L))
     sites_extracted <- Map(
       function(day) {
         cat(sprintf("Processing %s...\n", paste(day[1], "-", day[length(day)])))
@@ -499,8 +435,7 @@ calc_narr2 <- function(
       time_split
     )
     sites_extracted <- beethoven::reduce_merge(
-      sites_extracted,
-      by = c("site_id")
+      sites_extracted, by = c("site_id")
     )
   } else {
     sites_extracted <-
@@ -523,7 +458,8 @@ calc_narr2 <- function(
     tidyr::pivot_longer(cols = tidyselect::starts_with("MET_")) |>
     dplyr::rowwise() |>
     dplyr::mutate(
-      time = regmatches(
+      time =
+      regmatches(
         name,
         regexpr(
           "20[0-9]{2,2}[0-1][0-9][0-3][0-9]",
@@ -552,6 +488,8 @@ calc_narr2 <- function(
 }
 
 
+
+
 #' Parallelize NARR feature calculation
 #'
 #' This function parallelizes the processing and calculation of
@@ -566,6 +504,7 @@ calc_narr2 <- function(
 #' @return A list of results from the parallel processing.
 #' @export
 par_narr <- function(domain, path, date, locs) {
+
   if (!dir.exists(path)) {
     stop("The specified path does not exist.")
   }
@@ -587,6 +526,7 @@ par_narr <- function(domain, path, date, locs) {
       }
     )
   return(res)
+
 }
 
 #' Identify MODIS files
@@ -605,17 +545,15 @@ query_modis_files <- function(path, list, index) {
     path,
     full.names = TRUE,
     recursive = TRUE
-  ) |>
-    grep(
-      pattern = paste0(
-        "A",
-        list[[index]],
-        collapse = "|"
-      ),
-      value = TRUE
-    )
+  ) |> grep(
+    pattern = paste0(
+      "A", list[[index]], collapse = "|"
+    ),
+    value = TRUE
+  )
   return(grep_files)
 }
+
 
 
 #' Calculate MODIS product covariates in multiple CPU threads
@@ -742,10 +680,8 @@ calculate_modis <-
   ) {
     amadeus::check_geom(geom)
     if (!is.function(preprocess)) {
-      stop(
-        "preprocess should be one of process_modis_merge,
-process_modis_swath, or process_blackmarble."
-      )
+      stop("preprocess should be one of process_modis_merge,
+process_modis_swath, or process_blackmarble.")
     }
     # read all arguments
     # nolint start
@@ -784,25 +720,14 @@ process_modis_swath, or process_blackmarble."
 
     locs_input <- try(sf::st_as_sf(locs), silent = TRUE)
     if (inherits(locs_input, "try-error")) {
-      stop(
-        "locs cannot be convertible to sf.
-      Please convert locs into a sf object to proceed.\n"
-      )
+      stop("locs cannot be convertible to sf.
+      Please convert locs into a sf object to proceed.\n")
     }
 
     export_list <- c()
     package_list <-
-      c(
-        "sf",
-        "terra",
-        "exactextractr",
-        "data.table",
-        "stars",
-        "dplyr",
-        "parallelly",
-        "rlang",
-        "amadeus"
-      )
+      c("sf", "terra", "exactextractr", "data.table", "stars",
+        "dplyr", "parallelly", "rlang", "amadeus")
     if (!is.null(export_list_add)) {
       export_list <- append(export_list, export_list_add)
     }
@@ -834,54 +759,55 @@ process_modis_swath, or process_blackmarble."
             rlang::inject(preprocess(!!!hdf_args))
 
           if (sum(terra::nlyr(vrt_today)) != length(name_covariates)) {
-            message(
-              "The number of layers in the input raster do not match
-                    the length of name_covariates.\n"
-            )
+            message("The number of layers in the input raster do not match
+                    the length of name_covariates.\n")
           }
 
           res0 <-
-            lapply(radiusindexlist, function(k) {
-              name_radius <-
-                sprintf("%s%05d", name_covariates, radius[k])
-              extracted <-
-                try(
-                  amadeus::calculate_modis_daily(
-                    locs = locs_input,
-                    from = vrt_today,
-                    locs_id = locs_id,
-                    date = as.character(day_to_pick),
-                    fun_summary = fun_summary,
-                    name_extracted = name_radius,
-                    radius = radius[k],
-                    max_cells = max_cells,
-                    geom = FALSE
+            lapply(radiusindexlist,
+              function(k) {
+                name_radius <-
+                  sprintf("%s%05d",
+                          name_covariates,
+                          radius[k])
+                extracted <-
+                  try(
+                    amadeus::calculate_modis_daily(
+                      locs = locs_input,
+                      from = vrt_today,
+                      locs_id = locs_id,
+                      date = as.character(day_to_pick),
+                      fun_summary = fun_summary,
+                      name_extracted = name_radius,
+                      radius = radius[k],
+                      max_cells = max_cells,
+                      geom = FALSE
+                    )
                   )
-                )
-              if (inherits(extracted, "try-error")) {
-                # coerce to avoid errors
-                error_df <- data.frame(
-                  matrix(
-                    -99999,
-                    ncol = length(name_radius) + 1,
-                    nrow = nrow(locs_input)
+                if (inherits(extracted, "try-error")) {
+                  # coerce to avoid errors
+                  error_df <- data.frame(
+                    matrix(-99999,
+                           ncol = length(name_radius) + 1,
+                           nrow = nrow(locs_input))
                   )
-                )
-                error_df <- stats::setNames(error_df, c(locs_id, name_radius))
-                error_df[[locs_id]] <- unlist(locs_input[[locs_id]])
-                error_df$time <- day_to_pick
-                extracted <- error_df
+                  error_df <- stats::setNames(error_df, c(locs_id, name_radius))
+                  error_df[[locs_id]] <- unlist(locs_input[[locs_id]])
+                  error_df$time <- day_to_pick
+                  extracted <- error_df
+                }
+                return(extracted)
               }
-              return(extracted)
-            })
-          res <-
-            Reduce(
-              function(x, y) {
-                dplyr::left_join(x, y, by = c(locs_id, "time"))
-              },
-              res0
             )
+          res <-
+            Reduce(function(x, y) {
+              dplyr::left_join(x, y,
+                by = c(locs_id, "time")
+              )
+            },
+            res0)
           return(res)
+
         }
       )
     calc_results <- do.call(dplyr::bind_rows, calc_results)
@@ -902,3 +828,302 @@ process_modis_swath, or process_blackmarble."
     Sys.sleep(1L)
     return(calc_results_return)
   }
+
+
+
+#' Calculate MODIS from preprocessed file
+#' @param file character(1). File path of preprocessed GeoTIFF file.
+#' @param site data.frame/sf. AQS sites. data.frame will be converted to sf.
+#' @param site_id character(1). Unique identifier of `site`
+#' @param radius numeric(1). Circular buffer radius. Distance unit is inherited
+#'   from the sites' coordinate system.
+#' @param colheader character. Column name header.
+#' @param mark logical(1). Mark zero-padded (length of 5) radius in the column name.
+#' @importFrom chopin extract_at
+#' @importFrom sf st_as_sf
+#' @importFrom stats setNames
+#' @importFrom stringi stri_extract_first_regex
+#' @export 
+calculate_modis_direct <-
+  function(
+    file,
+    site,
+    site_id,
+    radius,
+    colheader,
+    mark = TRUE
+  ) {
+    radius <- as.integer(unlist(radius))
+    chr_padr <- sprintf("%05d", radius)
+    chr_coln <- if (mark) {
+      sprintf("%s%s", colheader, chr_padr)
+    } else {
+      colheader
+    }
+    print(chr_coln)
+    stopifnot(inherits(site, "data.frame"))
+
+    if (inherits(site, "SpatVector")) {
+      site <- try(sf::st_as_sf(site))
+    }
+    if (!inherits(site, "sf")) {
+      site <- try(sf::st_as_sf(site, sf_column_name = "geometry"))
+    }
+
+    # time info
+    chr_file1 <- file[1]
+    dateinfo <-
+      stringi::stri_extract_first_regex(chr_file1, pattern = "2[0-9]{3,3}\\-[0-1][0-9]\\-[0-3][0-9]")
+    dateinfo <- as.Date(dateinfo, format = "%Y-%m-%d")
+
+    extracted <-
+      chopin::extract_at(
+        x = file,
+        y = site,
+        id = site_id,
+        radius = radius
+      )
+    coln <- names(extracted)
+    coln_replace <- grep("(mean|median|min|max)", coln)
+    coln[coln_replace] <- chr_coln
+    extracted <- setNames(extracted, coln)
+    extracted[["time"]] <- dateinfo
+    return(extracted)
+  }
+
+
+
+
+#' Modified isotropic Sum of Exponentially Decaying Contributions (SEDC)
+#'   covariates
+#' @description
+#' Calculate toxic release values for polygons or isotropic buffer point
+#' locations. Returns a \code{data.frame} object containing \code{locs_id}
+#' and variables for each chemical in \code{from}.
+#' @param from SpatVector(1). Output of \code{process_tri()}.
+#' @param locs sf/SpatVector. Locations where TRI variables are calculated.
+#' @param locs_id character(1). Unique site identifier column name.
+#'  Default is `"site_id"`.
+#' @param radius integer(1). Circular buffer radius.
+#' @param ... Placeholders.
+#' @author Insang Song, Mariana Kassien
+#' @return a data.frame or SpatVector object
+#' @note U.S. context.
+#' @importFrom terra vect crs nearby hull buffer
+#' @importFrom methods is
+#' @importFrom data.table .SD rbindlist as.data.table merge.data.table
+#' @importFrom utils read.csv
+#' @importFrom dplyr ends_with all_of group_by ungroup
+#' @importFrom dplyr filter mutate across summarize
+#' @export
+calc_tri_mod <-
+  function(
+    from = NULL,
+    locs,
+    locs_id = "site_id",
+    radius = 1e3L,
+    ...
+  ) {
+    stopifnot(length(radius) == 1)
+    if (!methods::is(locs, "SpatVector")) {
+      if (methods::is(locs, "sf")) {
+        locs <- terra::vect(locs)
+      }
+    }
+    if (!is.numeric(radius)) {
+      stop("radius should be numeric.\n")
+    }
+    locs_re <- terra::project(locs, terra::crs(from))
+
+    # split by year: locs and tri locations
+    tri_cols <- grep("_AIR", names(from), value = TRUE)
+    # error fix: no whitespace
+    tri_cols <- sub(" ", "_", tri_cols)
+
+    # list_radius <- split(radius, radius)
+    locs_h <- terra::hull(locs)
+    locs_hb <-
+      terra::buffer(
+        locs_h,
+        width = radius,
+        joinstyle = "mitre",
+        capstyle = "square"
+      )
+
+    from_re <- from[locs_hb, ]
+
+    df_tri <-
+      sum_edc_mod(
+        locs = locs_re,
+        from = from_re,
+        locs_id = locs_id,
+        sedc_bandwidth = radius,
+        target_fields = tri_cols
+      )
+    # bind element data.frames into one
+    # df_tri <- data.table::as.data.table(df_tri)
+    names(df_tri) <- gsub("X[0-9]{4,5}\\.", "", names(df_tri))
+    if (nrow(df_tri) != nrow(locs)) {
+      df_tri <-
+        data.table::merge.data.table(
+          data.table::as.data.table(locs),
+          df_tri,
+          by = locs_id
+        )
+    }
+
+
+    # df_tri_return <- amadeus:::calc_return_locs(
+    #   covar = df_tri,
+    #   POSIXt = FALSE,
+    #   geom = geom,
+    #   crs = terra::crs(from)
+    # )
+
+    # read attr
+    df_tri$time <- as.integer(attr(from, "tri_year"))
+
+    return(df_tri)
+  }
+
+
+
+# nolint start
+#' Calculate isotropic Sum of Exponentially Decaying Contributions (SEDC) covariates
+#' @param from `SpatVector`(1). Point locations which contain point-source
+#' covariate data.
+#' @param locs sf/SpatVector(1). Locations where the sum of exponentially
+#' decaying contributions are calculated.
+#' @param locs_id character(1). Name of the unique id field in `point_to`.
+#' @param sedc_bandwidth numeric(1).
+#' Distance at which the source concentration is reduced to
+#'  `exp(-3)` (approximately -95 %)
+#' @param target_fields character(varying). Field names in characters.
+#' @return a data.frame (tibble) or SpatVector object with input field names with
+#'  a suffix \code{"_sedc"} where the sums of EDC are stored.
+#'  Additional attributes are attached for the EDC information.
+#'    - `attr(result, "sedc_bandwidth")``: the bandwidth where
+#'  concentration reduces to approximately five percent
+#'    - `attr(result, "sedc_threshold")``: the threshold distance
+#'  at which emission source points are excluded beyond that
+#' @note The function is originally from
+#' [chopin](https://github.com/ropensci/chopin)
+#' Distance calculation is done with terra functions internally.
+#'  Thus, the function internally converts sf objects in
+#'  \code{point_*} arguments to terra.
+#'  The threshold should be carefully chosen by users.
+#' @author Insang Song
+#' @references
+#' \insertRef{messier2012integrating}{amadeus}
+#' 
+#' \insertRef{web_sedctutorial_package}{amadeus}
+#' @examples
+#' set.seed(101)
+#' ncpath <- system.file("gpkg/nc.gpkg", package = "sf")
+#' nc <- terra::vect(ncpath)
+#' nc <- terra::project(nc, "EPSG:5070")
+#' pnt_locs <- terra::centroids(nc, inside = TRUE)
+#' pnt_locs <- pnt_locs[, "NAME"]
+#' pnt_from <- terra::spatSample(nc, 10L)
+#' pnt_from$pid <- seq(1, 10)
+#' pnt_from <- pnt_from[, "pid"]
+#' pnt_from$val1 <- rgamma(10L, 1, 0.05)
+#' pnt_from$val2 <- rgamma(10L, 2, 1)
+#'
+#' vals <- c("val1", "val2")
+#' sum_edc_mod(pnt_locs, pnt_from, "NAME", 1e4, vals)
+#' @importFrom collapse set_collapse qDT
+#' @importFrom terra nearby distance buffer
+#' @importFrom rlang sym
+#' @export
+# nolint end
+sum_edc_mod <-
+  function(
+    from = NULL,
+    locs = NULL,
+    locs_id = NULL,
+    sedc_bandwidth = NULL,
+    target_fields = NULL
+  ) {
+    collapse::set_collapse(mask = "manip")
+    if (!methods::is(locs, "SpatVector")) {
+      locs <- try(terra::vect(locs))
+    }
+    if (!methods::is(from, "SpatVector")) {
+      from <- try(terra::vect(from))
+    }
+
+    cn_overlap <- intersect(names(locs), names(from))
+    if (length(cn_overlap) > 0) {
+      warning(
+        sprintf(
+          "There are %d fields with the same name.
+The result may not be accurate.\n",
+          length(cn_overlap)
+        )
+      )
+    }
+    len_point_locs <- seq_len(nrow(locs))
+
+    locs$from_id <- len_point_locs
+    locs_buf <-
+      terra::buffer(
+        locs,
+        width = sedc_bandwidth * 2,
+        quadsegs = 90
+      )
+
+    from_in <- from[locs_buf, ]
+    len_point_from <- seq_len(nrow(from_in))
+
+    # len point from? len point to?
+    from_in$to_id <- len_point_from
+    dist <- NULL
+
+    # near features with distance argument: only returns integer indices
+    # threshold is set to the twice of sedc_bandwidth
+    res_nearby <-
+      terra::nearby(locs, from_in, distance = sedc_bandwidth * 2)
+    # attaching actual distance
+    dist_nearby <- terra::distance(locs, from_in)
+    dist_nearby_df <- as.vector(dist_nearby)
+    # adding integer indices
+    dist_nearby_tdf <-
+      expand.grid(
+        from_id = len_point_locs,
+        to_id = len_point_from
+      )
+    dist_nearby_df <- cbind(dist_nearby_tdf, dist = dist_nearby_df)
+
+    # summary
+    res_sedc <- res_nearby |>
+      as.data.table() |>
+      left_join(as.data.table(locs)) |>
+      left_join(as.data.table(from_in)) |>
+      left_join(as.data.table(dist_nearby_df)) |>
+      # per the definition in
+      # https://mserre.sph.unc.edu/BMElab_web/SEDCtutorial/index.html
+      # exp(-3) is about 0.05 * (value at origin)
+      mutate(w_sedc = exp((-3 * dist) / sedc_bandwidth)) |>
+      group_by(!!rlang::sym(locs_id)) |>
+      summarize(
+        across(
+          all_of(target_fields),
+          ~sum(w_sedc * ., na.rm = TRUE)
+        )
+      ) |>
+      ungroup()
+
+    idx_air <- grep("_AIR_", names(res_sedc))
+    names(res_sedc)[idx_air] <-
+      sprintf("%s_%05d", names(res_sedc)[idx_air], sedc_bandwidth)
+
+
+    attr(res_sedc, "sedc_bandwidth") <- sedc_bandwidth
+    attr(res_sedc, "sedc_threshold") <- sedc_bandwidth * 2
+
+    return(res_sedc)
+  }
+
+
+

--- a/inst/targets/targets_calculate_predict.R
+++ b/inst/targets/targets_calculate_predict.R
@@ -120,51 +120,6 @@ target_calculate_predict <-
       )
     )
     ,
-    ### VECTOR PROCESSING GRID ####
-    # targets::tar_target(
-    #   sf_pred_calc_split_v,
-    #   command = {
-    #     init_grid <-
-    #       chopin::par_pad_grid(
-    #         sf_pred_calc_grid,
-    #         mode = "grid",
-    #         nx = 30L,
-    #         ny = 15L,
-    #         padding = 100
-    #       )[[1]]
-    #     grid_sample <- dplyr::sample_frac(sf_pred_raw_grid, 0.01)
-    #     init_grid_intersect <-
-    #       init_grid[grid_sample, ]
-    #     if (!"grid_id" %in% names(init_grid_intersect)) {
-    #       init_grid_intersect$grid_id <- seq_len(nrow(init_grid_intersect))
-    #     }
-    #     init_grid_intersect
-    #   },
-    #   iteration = "vector",
-    #   description = "sf split grid polygons (for vector processing)"
-    # )
-    # ,
-    # targets::tar_target(
-    #   list_pred_calc_grid_v,
-    #   command = {
-    #     grid_unit <- sf::st_bbox(sf_pred_calc_split_v)
-    #     sf::st_as_sf(
-    #       df_pred_calc_gridcoords |>
-    #         dplyr::filter((lon <= grid_unit[3] & lon >= grid_unit[1]) & (lat <= grid_unit[4] & lat >= grid_unit[2])),
-    #       coords = c("lon", "lat"),
-    #       crs = 4326,
-    #       remove = FALSE
-    #     )
-
-    #   },
-    #   iteration = "list",
-    #   pattern = map(sf_pred_calc_split_v),
-    #   description = "Split prediction grid into list by chopin grid (DEV SAMPLE)",
-    #   resources = targets::tar_resources(
-    #     crew = targets::tar_resources_crew(controller = "controller_50")
-    #   )
-    # )
-    # ,
     ###########################         HMS          ###########################
     targets::tar_target(
       list_pred_calc_hms,
@@ -1053,7 +1008,7 @@ target_calculate_predict <-
       pattern = map(list_pred_calc_grid),
       description = "Calculate NEI features | prediction grid",
       resources = targets::tar_resources(
-        crew = targets::tar_resources_crew(controller = "controller_15"),
+        crew = targets::tar_resources_crew(controller = "controller_25"),
         parquet = targets::tar_resources_parquet(compression = "lz4")
       ),
       format = "parquet"
@@ -1146,7 +1101,7 @@ target_calculate_predict <-
       iteration = "list",
       pattern = map(list_pred_calc_grid),
       resources = targets::tar_resources(
-        crew = targets::tar_resources_crew(controller = "controller_15"),
+        crew = targets::tar_resources_crew(controller = "controller_10"),
         parquet = targets::tar_resources_parquet(compression = "lz4")
       ),
       format = "parquet",

--- a/inst/targets/targets_calculate_predict.R
+++ b/inst/targets/targets_calculate_predict.R
@@ -1,416 +1,849 @@
-################################################################################
-##### Calculate covariates at prediction grid
+
+## Targets for prediction grid features ####
+## TODO: prospective or retrospective, or both?
+# strategy: no all-merged data.frame (data.table)
+#           in-branch processing (using the branched target then pass it to targets_predict)
+# Each branched target should have the same degree of interaction (i.e., cross())
 target_calculate_predict <-
   list(
-    ############################################################################
     targets::tar_target(
-      list_feat_pred_sites,
-      command = {
-        df_pred_grid <- qs::qread(
-          file.path("inst", "extdata", "prediction_grid.qs")
+      library,
+      command = .Library
+    ),
+    targets::tar_target(
+      libPaths,
+      command = .libPaths()
+    ),
+    targets::tar_target(
+      df_pred_calc_grid,
+      command = qs::qread(
+        list.files(
+          path = file.path("inst", "extdata"),
+          pattern = "prediction_grid.qs",
+          full.names = TRUE
         )
-        df_pred_grid$site_id <- sprintf("P%08d", df_pred_grid$site_id)
-        sf_pred_grid <- sf::st_as_sf(
-          df_pred_grid,
+      ),
+      description = "Import prediction grid"
+    ),
+    targets::tar_target(
+      sf_pred_raw_grid,
+      command = sf::st_transform(
+        sf::st_as_sf(
+          df_pred_calc_grid,
           coords = c("lon", "lat"),
           crs = 5070
-        )
-        num_size_subgrid <- 1000
-        num_pred_list_length <- nrow(sf_pred_grid) / num_size_subgrid
-        sf_pred_grid$group <- rep(
-          1:num_pred_list_length,
-          length.out = nrow(sf_pred_grid)
-        )
-        list_pred_grid <- split(sf_pred_grid, sf_pred_grid$group)
-        list_pred_grid <- lapply(
-          list_pred_grid,
-          function(x) x[1:10, "site_id"]
-        )
-        list_pred_grid[1:2]
-      },
-      description = "Prediction locations | pred | DEV (2 list objects; 10 sites each)"
-    ),
-    targets::tar_target(
-      dt_feat_pred_sites,
-      command = sf_feat_pred_sites %>%
-        sf::st_drop_geometry() %>%
-        tidyr::crossing(chr_dates) %>%
-        dplyr::rename(time = chr_dates) %>%
-        data.table::data.table(),
-      description = "Prediction locations with time | pred"
-    ),
-    ############################################################################
-    ###########################         GEOS         ###########################
-    targets::tar_target(
-      list_feat_pred_geos_aqc,
-      command = {
-        download_geos_buffer
-        beethoven::calc_geos_strict(
-          path = file.path(chr_input_dir, "geos", chr_iter_calc_geos[1]),
-          date = beethoven::fl_dates(unlist(list_dates)),
-          locs = list_feat_pred_sites[[1]],
-          locs_id = "site_id"
-        )
-      },
-      pattern = cross(list_feat_pred_sites, list_dates),
-      resources = targets::tar_resources(
-        crew = targets::tar_resources_crew(controller = "controller_100")
+        ),
+        crs = 4326
       ),
-      iteration = "list",
-      description = "Calculate GEOS-CF features | aqc | pred"
+      description = "Prediction grid as sf (no coordinates)"
     ),
     targets::tar_target(
-      list_feat_pred_geos_chm,
-      command = {
-        download_geos_buffer
-        beethoven::calc_geos_strict(
-          path = file.path(chr_input_dir, "geos", chr_iter_calc_geos[2]),
-          date = beethoven::fl_dates(unlist(list_dates)),
-          locs = list_feat_pred_sites[[1]],
-          locs_id = "site_id"
-        )
-      },
-      pattern = cross(list_feat_pred_sites, list_dates),
-      resources = targets::tar_resources(
-        crew = targets::tar_resources_crew(controller = "controller_100")
+      df_pred_raw_grid,
+      command = sf::st_coordinates(sf_pred_raw_grid),
+      description = "Prediction grid coordinates as df"
+    ),
+    targets::tar_target(
+      sf_pred_calc_grid,
+      command = cbind(
+        sf_pred_raw_grid,
+        lon = df_pred_raw_grid[, 1],
+        lat = df_pred_raw_grid[, 2]
       ),
-      iteration = "list",
-      description = "Calculate GEOS-CF features | chm | pred"
-    ),
-    # targets::tar_target(
-    #   dt_feat_pred_geos,
-    #   command = beethoven::reduce_merge(
-    #     c(
-    #       beethoven::reduce_list(list_feat_pred_geos_aqc),
-    #       beethoven::reduce_list(list_feat_pred_geos_chm)
-    #     ),
-    #     by = c("site_id", "time", "CO", "NO2", "SO2")
-    #   ),
-    #   description = "data.table of GEOS-CF features | pred"
-    # ),
-    ###########################         NARR         ###########################
+      description = "Prediction grid as sf (with coordinates)"
+    )
+    ,
     targets::tar_target(
-      list_feat_pred_narr,
+      df_pred_calc_gridcoords,
+      command = sf::st_drop_geometry(
+        sf_pred_calc_grid
+      ),
+      description = "Prediction grid as tibble (with coordinates)"
+    )
+    ,
+    targets::tar_target(
+      name = chr_pred_calc_grid,
+      command = names(list_pred_calc_grid),
+      description = "Names of prediction grid sf objects (SAMPLE)"
+    )
+    ,
+    targets::tar_target(
+      list_pred_split_dates,
+      command = split_dates(arglist_common$char_period, 50),
+      description = "Split period into list of dates"
+    )
+    ,
+    targets::tar_target(
+      chr_pred_split_dates,
+      command = names(list_pred_split_dates),
+      description = "Names of split dates lists"
+    )
+    ,
+    ###########################################################################
+    ##### SAMPLE TARGETS FOR DEVELOPMENT #####
+    targets::tar_target(
+      sf_pred_calc_split,
       command = {
-        download_narr_buffer
-        dt_iter_pred_narr <- amadeus::calculate_narr(
-          from = amadeus::process_narr(
-            path = file.path(chr_input_dir, "narr", chr_iter_calc_narr),
-            variable = chr_iter_calc_narr,
-            date = beethoven::fl_dates(unlist(list_dates))
-          ),
-          locs = list_feat_pred_sites[[1]],
-          locs_id = "site_id",
-          radius = 0,
-          fun = "mean",
-          geom = FALSE
-        )
-        if (length(grep("level", names(dt_iter_pred_narr))) == 1) {
-          dt_iter_pred_narr <-
-            dt_iter_pred_narr[dt_iter_pred_narr$level == 1000, ]
-          dt_iter_pred_narr <-
-            dt_iter_pred_narr[, -grep("level", names(dt_iter_pred_narr))]
-        }
-        beethoven::post_calc_cols(
-          dt_iter_pred_narr,
-          prefix = "NARR_0_"
+        init_grid <-
+          chopin::par_pad_grid(
+            sf_pred_calc_grid,
+            mode = "grid",
+            nx = 10L,
+            ny = 5L,
+            padding = 100
+          )[[1]]
+        grid_sample <- dplyr::sample_frac(sf_pred_raw_grid, 0.01)
+        init_grid_intersect <-
+          init_grid[grid_sample, ]
+        init_grid_intersect
+      },
+      iteration = "vector",
+      description = "sf split grid polygons"
+    )
+    ,
+    targets::tar_target(
+      list_pred_calc_grid,
+      command = {
+        grid_unit <- sf::st_bbox(sf_pred_calc_split)
+        sf::st_as_sf(
+          df_pred_calc_gridcoords |>
+            dplyr::filter((lon <= grid_unit[3] & lon >= grid_unit[1]) & (lat <= grid_unit[4] & lat >= grid_unit[2])),
+          coords = c("lon", "lat"),
+          crs = 4326,
+          remove = FALSE
         )
       },
-      pattern = cross(list_feat_pred_sites, list_dates, chr_iter_calc_narr),
       iteration = "list",
-      description = "Calculate NARR features | nolag | pred"
-    ),
+      pattern = map(sf_pred_calc_split),
+      description = "Split prediction grid into list by chopin grid (DEV SAMPLE)",
+      resources = targets::tar_resources(
+        crew = targets::tar_resources_crew(controller = "controller_50")
+      )
+    )
+    ,
+    ### VECTOR PROCESSING GRID ####
     # targets::tar_target(
-    #   dt_feat_pred_narr_nolag,
-    #   command = beethoven::reduce_merge(
-    #     beethoven::reduce_list(list_feat_pred_narr),
-    #     by = c("site_id", "time")
-    #   ),
-    #   description = "data.table of NARR features | nolag | pred"
-    # ),
-    targets::tar_target(
-      list_feat_pred_narr_lag,
-      command = {
-        download_narr_buffer
-        dt_lag_pred_narr <- amadeus::calculate_narr(
-          from = amadeus::process_narr(
-            path = file.path(chr_input_dir, "narr", chr_iter_calc_narr_lag),
-            variable = chr_iter_calc_narr_lag,
-            date = as.character(chr_dates[1] - 1)
-          ),
-          locs = dplyr::bind_rows(list_feat_pred_sites),
-          locs_id = "site_id",
-          radius = 0,
-          fun = "mean",
-          geom = FALSE
-        )
-        if (length(grep("level", names(dt_lag_pred_narr))) == 1) {
-          dt_lag_pred_narr <-
-            dt_lag_pred_narr[dt_lag_pred_narr$level == 1000, ]
-          dt_lag_pred_narr <-
-            dt_lag_pred_narr[, -grep("level", names(dt_lag_pred_narr))]
-        }
-        dt_lag_pred_narr <- beethoven::post_calc_cols(
-          dt_lag_pred_narr,
-          prefix = "NARR_0_"
-        )
-        int_narr_cols <- which(
-          names(dt_feat_pred_narr_nolag) %in% names(dt_lag_pred_narr)
-        )
-        dt_iter_pred_narr_bind <- rbind(
-          dt_lag_pred_narr,
-          dt_feat_pred_narr_nolag[, int_narr_cols, with = FALSE]
-        )
-        amadeus::calculate_lagged(
-          from = dt_iter_pred_narr_bind,
-          date = chr_daterange,
-          lag = 1,
-          locs_id = "site_id"
-        )
-      },
-      pattern = map(chr_iter_calc_narr_lag),
-      iteration = "list",
-      description = "Calculate NARR features | lag | pred"
-    ),
+    #   sf_pred_calc_split_v,
+    #   command = {
+    #     init_grid <-
+    #       chopin::par_pad_grid(
+    #         sf_pred_calc_grid,
+    #         mode = "grid",
+    #         nx = 30L,
+    #         ny = 15L,
+    #         padding = 100
+    #       )[[1]]
+    #     grid_sample <- dplyr::sample_frac(sf_pred_raw_grid, 0.01)
+    #     init_grid_intersect <-
+    #       init_grid[grid_sample, ]
+    #     if (!"grid_id" %in% names(init_grid_intersect)) {
+    #       init_grid_intersect$grid_id <- seq_len(nrow(init_grid_intersect))
+    #     }
+    #     init_grid_intersect
+    #   },
+    #   iteration = "vector",
+    #   description = "sf split grid polygons (for vector processing)"
+    # )
+    # ,
     # targets::tar_target(
-    #   dt_feat_calc_narr,
-    #   command = beethoven::reduce_merge(
-    #     beethoven::reduce_list(
-    #       c(list(dt_feat_calc_narr_nolag), list_feat_calc_narr_lag)
-    #     ),
-    #     by = c("site_id", "time")
-    #   ),
-    #   description = "data.table of NARR features | pred"
-    # ),
+    #   list_pred_calc_grid_v,
+    #   command = {
+    #     grid_unit <- sf::st_bbox(sf_pred_calc_split_v)
+    #     sf::st_as_sf(
+    #       df_pred_calc_gridcoords |>
+    #         dplyr::filter((lon <= grid_unit[3] & lon >= grid_unit[1]) & (lat <= grid_unit[4] & lat >= grid_unit[2])),
+    #       coords = c("lon", "lat"),
+    #       crs = 4326,
+    #       remove = FALSE
+    #     )
+
+    #   },
+    #   iteration = "list",
+    #   pattern = map(sf_pred_calc_split_v),
+    #   description = "Split prediction grid into list by chopin grid (DEV SAMPLE)",
+    #   resources = targets::tar_resources(
+    #     crew = targets::tar_resources_crew(controller = "controller_50")
+    #   )
+    # )
+    # ,
     ###########################         HMS          ###########################
     targets::tar_target(
-      list_feat_pred_hms,
+      list_pred_calc_hms,
       command = {
-        download_hms_buffer
-        dt_iter_pred_hms <- beethoven::inject_calculate(
-          covariate = "hms",
-          locs = list_feat_pred_sites[[1]],
-          injection = list(
-            path = file.path(chr_input_dir, "hms", "data_files"),
-            date = beethoven::fl_dates(unlist(list_dates)),
-            covariate = "hms"
+        # lapply
+        lapply(list_dates, function(d) {
+
+          beethoven::inject_calculate(
+            covariate = "hms",
+            locs = list_pred_calc_grid,
+            injection = list(
+              path = file.path(chr_input_dir, "hms", "data_files"),
+              date = beethoven::fl_dates(unlist(d)), # used to be unlist(list_dates)
+              covariate = "hms"
+            )
+          )[[1]] |>
+            dplyr::select(-dplyr::any_of(c("lon", "lat", "geometry", "hms_year")))
+        }) %>%
+        collapse::rowbind() %>%
+        as.data.frame()
+
+      },
+      pattern = map(list_pred_calc_grid),
+      iteration = "list",
+      description = "Calculate HMS features | prediction",
+      resources = targets::tar_resources(
+        crew = targets::tar_resources_crew(controller = "controller_50")
+      )
+    )
+    ,
+    ##############################   NLCD    #############################
+    # Added for test
+    targets::tar_target(
+      chr_iter_calc_nlcd,
+      command = c(2019, 2021),
+      description = "NLCD years | download"
+    )
+    ,
+    targets::tar_target(
+      chr_pred_calc_nlcd_radii,
+      command = c(1000, 10000),
+      description = "NLCD radii | download"
+    )
+    ,
+    targets::tar_target(
+      name = list_pred_calc_nlcd,
+      command =
+      {
+        unique_radii <- chr_pred_calc_nlcd_radii
+        nlcd_years <- chr_iter_calc_nlcd
+        grid_rowids <- seq_len(nrow(list_pred_calc_grid))
+        grid_rowidx <- split(
+            grid_rowids,
+            ceiling(grid_rowids / 5000)
           )
-        )[[1]] |>
-          dplyr::select(-dplyr::any_of(c("lon", "lat", "geometry", "hms_year")))
-        beethoven::post_calc_cols(
-          dt_iter_pred_hms,
-          prefix = "HMS_"
+        # threefold lists
+        # First level: years (rowbind)
+        lapply(
+          nlcd_years,
+          function(year) {
+            # Second level: radii (full join)
+            lapply(
+              unique_radii,
+              function(radi) {
+                # Third level: chunked rows (rowbind)
+                lapply(
+                  grid_rowidx,
+                  function(rows) {
+                    inject_nlcd(
+                      year = year,
+                      radius = radi,
+                      from = amadeus::process_nlcd(
+                        path = file.path(chr_input_dir, "nlcd", "data_files"),
+                        year = year,
+                      ),
+                      locs = list_pred_calc_grid[rows, ],
+                      locs_id = arglist_common$char_siteid,
+                      mode = "exact",
+                      max_cells = 3e7
+                    )
+                  }
+                ) %>%
+                collapse::rowbind(., fill = TRUE)
+              }) %>%
+              Reduce(f = function(d, e) dplyr::full_join(d, e, by = c("site_id", "time")), .)
+          }
+        ) %>%
+        collapse::rowbind(., fill = TRUE) %>%
+        as.data.frame()
+
+      }
+      ,
+      pattern = map(list_pred_calc_grid),
+      iteration = "list",
+      format = "parquet",
+      description = "Calculate NLCD features | prediction",
+      resources = targets::tar_resources(
+        crew = targets::tar_resources_crew(controller = "controller_25"),
+        parquet = targets::tar_resources_parquet(compression = "lz4")
+      )
+    )
+    ,
+    ##############################   GMTED    #############################
+    targets::tar_target(
+      chr_pred_calc_gmted_radii,
+      # command = c(0, 1e3, 1e4, 5e4),
+      command = c(200),
+      description = "Radii for GMTED features"
+    )
+    ,
+    targets::tar_target(
+      chr_iter_calc_gmted_vars,
+      command = c(
+        "Breakline Emphasis", "Systematic Subsample",
+        "Median Statistic", "Minimum Statistic",
+        "Mean Statistic", "Maximum Statistic",
+        "Standard Deviation Statistic"
+      ),
+      description = "GMTED features | download"
+    )
+    ,
+    targets::tar_target(
+      name = list_pred_calc_gmted,
+      command =
+      {
+        mapply(
+          function(var, radi) {
+            
+            beethoven::calc_gmted_direct(
+              variable = c(var, "7.5 arc-seconds"),
+              path = file.path(chr_input_dir, "gmted", "data_files"),
+              locs = list_pred_calc_grid,
+              locs_id = "site_id",
+              radius = radi
+            )
+          },
+          chr_iter_calc_gmted_vars,
+          chr_pred_calc_gmted_radii,
+          SIMPLIFY = FALSE
+        ) %>%
+        Reduce(
+          f = function(d, e) dplyr::full_join(d, e, by = c("site_id")),
+          .
         )
       },
-      pattern = cross(list_feat_pred_sites, list_dates),
       iteration = "list",
-      description = "Calculate HMS features | pred"
-    ),
-    # targets::tar_target(
-    #   dt_feat_pred_hms,
-    #   command = beethoven::reduce_list(list_feat_pred_hms)[[1]],
-    #   description = "data.table of HMS features | pred"
-    # ),
-    ###########################       MODIS - MOD11       ######################
-    targets::tar_target(
-      list_feat_pred_mod11,
-      command = beethoven::inject_modis(
-        locs = list_feat_pred_sites[[1]],
-        injection = list_args_calc_mod11
-      ),
-      pattern = cross(list_feat_pred_sites, list_args_calc_mod11),
-      iteration = "list",
-      resources = targets::tar_resources(
-        crew = targets::tar_resources_crew(controller = "controller_50")
-      ),
-      description = "Calculate MODIS - MOD11 features | pred"
-    ),
-    ###########################       MODIS - MOD06       ######################
-    targets::tar_target(
-      list_feat_pred_mod06,
-      command = beethoven::inject_modis(
-        locs = list_feat_pred_sites[[1]],
-        injection = list_args_calc_mod06
-      ),
-      pattern = cross(list_feat_pred_sites, list_args_calc_mod06),
-      iteration = "list",
-      resources = targets::tar_resources(
-        crew = targets::tar_resources_crew(controller = "controller_50")
-      ),
-      description = "Calculate MODIS - MOD06 features | pred"
-    ),
-    ###########################       MODIS - MOD13       ######################
-    targets::tar_target(
-      list_feat_pred_mod13,
-      command = beethoven::inject_modis(
-        locs = list_feat_pred_sites[[1]],
-        injection = list_args_calc_mod13
-      ),
-      pattern = cross(list_feat_pred_sites, list_args_calc_mod13),
-      iteration = "list",
-      resources = targets::tar_resources(
-        crew = targets::tar_resources_crew(controller = "controller_100")
-      ),
-      description = "Calculate MODIS - MOD13 features | pred"
-    ),
-    ###########################     MODIS - MCD19_1km     ######################
-    targets::tar_target(
-      list_feat_pred_mcd19_1km,
-      command = beethoven::inject_modis(
-        locs = list_feat_pred_sites[[1]],
-        injection = list_args_calc_mcd19_1km
-      ),
-      pattern = cross(list_feat_pred_sites, list_args_calc_mcd19_1km),
-      iteration = "list",
-      resources = targets::tar_resources(
-        crew = targets::tar_resources_crew(controller = "controller_250")
-      ),
-      description = "Calculate MODIS - MCD19_1km features | pred"
-    ),
-    ###########################     MODIS - MCD19_5km     ######################
-    targets::tar_target(
-      list_feat_pred_mcd19_5km,
-      command = beethoven::inject_modis(
-        locs = list_feat_pred_sites[[1]],
-        injection = list_args_calc_mcd19_5km
-      ),
-      pattern = cross(list_feat_pred_sites, list_args_calc_mcd19_5km),
-      iteration = "list",
-      resources = targets::tar_resources(
-        crew = targets::tar_resources_crew(controller = "controller_250")
-      ),
-      description = "Calculate MODIS - MCD19_5km features | pred"
-    ),
-    ###########################       MODIS - MOD09       ######################
-    targets::tar_target(
-      list_feat_pred_mod09,
-      command = beethoven::inject_modis(
-        locs = list_feat_pred_sites[[1]],
-        injection = list_args_calc_mod09
-      ),
-      pattern = cross(list_feat_pred_sites, list_args_calc_mod09),
-      iteration = "list",
+      pattern = map(list_pred_calc_grid),
       resources = targets::tar_resources(
         crew = targets::tar_resources_crew(controller = "controller_25")
       ),
-      description = "Calculate MODIS - MOD09 features | pred"
-    ),
-    ###########################       MODIS - VIIRS       ######################
+      description = "Calculate GMTED features | prediction"
+    )
+    ,
+    ###########################         GEOS         ###########################
     targets::tar_target(
-      list_feat_pred_viirs,
-      command = beethoven::inject_modis(
-        locs = list_feat_pred_sites[[1]],
-        injection = list_args_calc_viirs
+      list_pred_calc_geos_aqc,
+      command = {
+        download_geos_buffer <- TRUE
+        aqc_extract <- beethoven::calc_geos_strict(
+          path = file.path(chr_input_dir, "geos", chr_iter_calc_geos[1]),
+          date = beethoven::fl_dates(unlist(list_dates)),
+          locs = list_pred_calc_grid,
+          locs_id = "site_id"
+        )
+        target_idx <- which(names(aqc_extract) %in% c("site_id", "time"))
+        names(aqc_extract)[-target_idx] <- paste0("ATM_GOAQC_", names(aqc_extract)[-target_idx], "_0_00000")
+        aqc_extract
+      },
+      pattern = cross(list_pred_calc_grid, list_dates),
+      resources = targets::tar_resources(
+        crew = targets::tar_resources_crew(controller = "controller_50")
       ),
-      pattern = cross(list_feat_pred_sites, list_args_calc_viirs),
+      iteration = "list",
+      description = "Calculate GEOS-CF features | aqc | prediction"
+    )
+    ,
+    targets::tar_target(
+      list_pred_calc_geos_chm,
+      command = {
+        # download_geos_buffer
+        chm_extract <- beethoven::calc_geos_strict(
+          path = file.path(chr_input_dir, "geos", chr_iter_calc_geos[2]),
+          date = beethoven::fl_dates(unlist(list_dates)),
+          locs = list_pred_calc_grid,
+          locs_id = "site_id"
+        )
+        target_idx <- which(names(chm_extract) %in% c("site_id", "time"))
+        names(chm_extract)[-target_idx] <- paste0("ATM_GOCHM_", names(chm_extract)[-target_idx], "_0_00000")
+        chm_extract
+      },
+      pattern = cross(list_pred_calc_grid, list_dates),
+      resources = targets::tar_resources(
+        crew = targets::tar_resources_crew(controller = "controller_50")
+      ),
+      iteration = "list",
+      description = "Calculate GEOS-CF features | chm | prediction"
+    )
+    ,
+    ###########################         NARR         ###########################
+    targets::tar_target(
+      chr_iter_calc_narr,
+      command = c(
+        "air.sfc", "albedo", "apcp", "dswrf", "evap", "hcdc", "hpbl",
+        "lcdc", "lhtfl", "mcdc", "pr_wtr", "prate", "pres.sfc",
+        "shtfl", "snowc", "soilm", "tcdc", "ulwrf.sfc", "uwnd.10m",
+        "vis", "vwnd.10m", "weasd", "omega", "shum"
+      ),
+      description = "NARR features"
+    )
+    ,
+    targets::tar_target(
+      list_pred_calc_narr,
+      command = {
+        # download_narr_buffer <- TRUE
+        lapply(
+          chr_iter_calc_narr,
+          function(name) {
+            dt_iter_calc_narr <- amadeus::calculate_narr(
+              from = amadeus::process_narr(
+                path = file.path(chr_input_dir, "narr", name),
+                variable = name,
+                date = beethoven::fl_dates(unlist(list_dates))
+              ),
+              locs = list_pred_calc_grid,
+              locs_id = "site_id",
+              radius = 0,
+              fun = "mean",
+              geom = FALSE
+            )
+            if (length(grep("level", names(dt_iter_calc_narr))) == 1) {
+              dt_iter_calc_narr <-
+                dt_iter_calc_narr[dt_iter_calc_narr$level == 1000, ]
+              dt_iter_calc_narr <-
+                dt_iter_calc_narr[, -grep("level", names(dt_iter_calc_narr))]
+            }
+            dt_iter_calc_narr
+          }) %>%
+          Reduce(
+            f = function(d, e) dplyr::full_join(d, e, by = c("site_id", "time")),
+            .
+          ) %>%
+          as.data.frame()
+      },
+      pattern = cross(list_pred_calc_grid, list_dates),
       iteration = "list",
       resources = targets::tar_resources(
-        crew = targets::tar_resources_crew(controller = "controller_100")
+        crew = targets::tar_resources_crew(controller = "controller_10"),
+        parquet = targets::tar_resources_parquet(compression = "lz4")
       ),
-      description = "Calculate MODIS - VIIRS features | pred"
-    ),
-    ###########################        MODIS/VIIRS        ######################
-    # targets::tar_target(
-    #   dt_feat_pred_nasa,
-    #   command = beethoven::reduce_merge(
-    #     lapply(
-    #       list(
-    #         list_feat_pred_mod11,
-    #         list_feat_pred_mod06,
-    #         list_feat_pred_mod13,
-    #         list_feat_pred_mcd19_1km,
-    #         list_feat_pred_mcd19_5km,
-    #         list_feat_pred_mod09,
-    #         list_feat_pred_viirs
-    #       ),
-    #       function(x) data.table::data.table(beethoven::reduce_list(x)[[1]])
-    #     ),
-    #     by = NULL
-    #   ),
-    #   description = "data.table of MODIS/VIIRS features | pred"
-    # ),
-    ###########################         GMTED        ###########################
+      format = "parquet",
+      description = "Calculate NARR features | prediction"
+    )
+    ,
+    ###########################       MODIS - MOD11       ######################
     targets::tar_target(
-      list_feat_pred_gmted,
+      list_pred_calc_mod11,
       command = {
-        download_gmted
-        beethoven::calc_gmted_direct(
-          variable = c(chr_iter_calc_gmted_vars, "7.5 arc-seconds"),
-          path = file.path(chr_input_dir, "gmted", "data_files"),
-          locs = list_feat_pred_sites[[1]],
-          locs_id = "site_id",
-          radius = chr_iter_calc_gmted_radii
-        )
+        search_dir <- file.path(chr_input_dir, "modis_preprocessed", "MOD11A1")
+        date_find <- list_dates
+        
+        lapply(chr_iter_radii, function(r) {
+          Map(
+            f = function(date_i) {
+              date_in <- paste("(", date_i, ")", sep = "")
+              target_file <- list.files(
+                path = search_dir,
+                pattern = paste0(date_in, "\\.tif$"),
+                full.names = TRUE
+              )
+              res <- tryCatch({
+                beethoven::calculate_modis_direct(
+                  file = target_file, #chr_list_calc_mod11_files,
+                  site = list_pred_calc_grid,
+                  site_id = arglist_common[["char_siteid"]],
+                  radius = r,
+                  colheader = c("MOD_SFCTD_0_", "MOD_SFCTN_0_"),
+                  mark = TRUE
+                )
+              }, error = function(e) {
+                res <- expand.grid(
+                  site_id = list_pred_calc_grid[["site_id"]],
+                  time = date_i,
+                  MOD_SFCTD_0_ = NA_real_,
+                  MOD_SFCTN_0_ = NA_real_
+                )
+                names(res)[3:4] <- paste0(names(res)[3:4], sprintf("%05d", r))
+                return(res)
+              })
+              res
+
+            },
+            date_find
+          ) %>%
+          collapse::rowbind(., fill = TRUE)
+        }) %>%
+          Reduce(
+            f = function(d, e) {dplyr::full_join(d, e, by = c("site_id", "time"))},
+            .
+          ) %>%
+          as.data.frame()
       },
+      pattern = cross(list_pred_calc_grid, list_dates),
       iteration = "list",
-      pattern = cross(
-        list_feat_pred_sites,
-        chr_iter_calc_gmted_vars,
-        chr_iter_calc_gmted_radii
+      resources = targets::tar_resources(
+        crew = targets::tar_resources_crew(controller = "controller_50"),
+        parquet = targets::tar_resources_parquet(compression = "lz4")
       ),
-      description = "Calculate GMTED features | pred"
-    ),
-    # targets::tar_target(
-    #   dt_feat_pred_gmted,
-    #   command = beethoven::reduce_merge(
-    #     beethoven::reduce_list(list_feat_pred_gmted),
-    #     by = "site_id"
-    #   ),
-    #   description = "data.table of GMTED features | pred"
-    # ),
-    ###########################         NLCD         ###########################
+      format = "parquet",
+      description = "Calculate MODIS - MOD11 features | prediction"
+    )
+    ,
+    ###########################       MODIS - MOD06       ######################
     targets::tar_target(
-      list_feat_pred_nlcd,
+      list_pred_calc_mod06,
       command = {
-        download_nlcd
-        beethoven::inject_nlcd(
-          locs = dplyr::bind_rows(list_feat_pred_sites),
-          # NOTE: locs are all AQS sites for computational efficiency
-          locs_id = "site_id",
-          year = df_feat_calc_nlcd_params$year,
-          radius = df_feat_calc_nlcd_params$radius,
-          from = amadeus::process_nlcd(
-            path = file.path(chr_input_dir, "nlcd2", "data_files"),
-            year = df_feat_calc_nlcd_params$year
-          ),
-          nthreads = 1,
-          mode = "exact",
-          max_cells = 3e7
-        )
+        search_dir <- file.path(chr_input_dir, "modis_preprocessed", "MOD06_L2")
+        date_find <- list_dates
+        
+        lapply(chr_iter_radii, function(r) {
+          Map(
+            f = function(date_i) {
+              date_in <- paste("(", date_i, ")", sep = "")
+              target_file <- list.files(
+                path = search_dir,
+                pattern = paste0(date_in, "\\.tif$"),
+                full.names = TRUE
+              )
+              res <- tryCatch({
+                beethoven::calculate_modis_direct(
+                  file = target_file,
+                  site = list_pred_calc_grid,
+                  site_id = arglist_common[["char_siteid"]],
+                  radius = r,
+                  colheader = c("MOD_CLCVD_0_", "MOD_CLCVN_0_"),
+                  mark = TRUE
+                )
+              }, error = function(e) {
+                res <- expand.grid(
+                  site_id = list_pred_calc_grid[["site_id"]],
+                  time = date_i,
+                  MOD_CLCVD_0_ = NA_real_,
+                  MOD_CLCVN_0_ = NA_real_
+                )
+                names(res)[3:4] <- paste0(names(res)[3:4], sprintf("%05d", r))
+                return(res)
+              })
+              res
+
+            },
+            date_find
+          ) %>%
+          collapse::rowbind(., fill = TRUE)
+        }) %>%
+          Reduce(
+            f = function(d, e) {dplyr::full_join(d, e, by = c("site_id", "time"))},
+            .
+          ) %>%
+          as.data.frame()
       },
+      pattern = cross(list_pred_calc_grid, list_dates),
       iteration = "list",
-      pattern = map(df_feat_calc_nlcd_params),
-      description = "Calculate NLCD features | pred"
-    ),
-    # targets::tar_target(
-    #   name = dt_feat_pred_nlcd,
-    #   command = list_feat_pred_nlcd %>%
-    #     collapse::rowbind(fill = TRUE) %>%
-    #     collapse::funique() %>%
-    #     collapse::pivot(
-    #       ids = c("site_id", "time"),
-    #       values = names(.)[
-    #         !names(.) %in%
-    #           c(
-    #             "site_id",
-    #             "time"
-    #           )
-    #       ]
-    #     ) %>%
-    #     .[!is.na(.[["value"]]), ] %>%
-    #     collapse::pivot(
-    #       ids = c("site_id", "time"),
-    #       values = c("value"),
-    #       how = "wider"
-    #     ),
-    #   description = "NLCD feature list (all dt) | pred"
-    # ),
+      resources = targets::tar_resources(
+        crew = targets::tar_resources_crew(controller = "controller_50"),
+        parquet = targets::tar_resources_parquet(compression = "lz4")
+      ),
+      format = "parquet",
+      description = "Calculate MODIS - MOD06 features | prediction"
+    )
+    ,
+    ###########################       MODIS - MOD13       ######################
+    targets::tar_target(
+      list_pred_calc_mod13,
+      command = {
+        search_dir <- file.path(chr_input_dir, "modis_preprocessed", "MOD13A1")
+        date_find <- list_dates
+        
+        lapply(chr_iter_radii, function(r) {
+          Map(
+            f = function(date_i) {
+              date_in <- paste("(", date_i, ")", sep = "")
+              target_file <- list.files(
+                path = search_dir,
+                pattern = paste0(date_in, "\\.tif$"),
+                full.names = TRUE
+              )
+              res <- tryCatch({
+                beethoven::calculate_modis_direct(
+                  file = target_file,
+                  site = list_pred_calc_grid,
+                  site_id = arglist_common[["char_siteid"]],
+                  radius = r,
+                  colheader = c("MOD_NDVIV_0_"),
+                  mark = TRUE
+                )
+              }, error = function(e) {
+                res <- expand.grid(
+                  site_id = list_pred_calc_grid[["site_id"]],
+                  time = date_i,
+                  MOD_NDVIV_0_ = NA_real_
+                )
+                names(res)[3] <- paste0(names(res)[3], sprintf("%05d", r))
+                return(res)
+              })
+              res
+
+            },
+            date_find
+          ) %>%
+          collapse::rowbind(., fill = TRUE)
+        }) %>%
+          Reduce(
+            f = function(d, e) {dplyr::full_join(d, e, by = c("site_id", "time"))},
+            .
+          ) %>%
+          as.data.frame()
+      },
+      pattern = cross(list_pred_calc_grid, list_dates),
+      iteration = "list",
+      resources = targets::tar_resources(
+        crew = targets::tar_resources_crew(controller = "controller_50"),
+        parquet = targets::tar_resources_parquet(compression = "lz4")
+      ),
+      format = "parquet",
+      description = "Calculate MODIS - MOD13 features | prediction"
+    )
+    ,
+    ###########################     MODIS - MCD19_1km     ######################
+    targets::tar_target(
+      list_pred_calc_mcd19_1km,
+      command = {
+        search_dir <- file.path(chr_input_dir, "modis_preprocessed", "MCD19A2_1km")
+        date_find <- list_dates
+        
+        lapply(chr_iter_radii, function(r) {
+          Map(
+            f = function(date_i) {
+              date_in <- paste("(", date_i, ")", sep = "")
+              target_file <- list.files(
+                path = search_dir,
+                pattern = paste0(date_in, "\\.tif$"),
+                full.names = TRUE
+              )
+              res <- tryCatch({
+                beethoven::calculate_modis_direct(
+                  file = target_file,
+                  site = list_pred_calc_grid,
+                  site_id = arglist_common[["char_siteid"]],
+                  radius = r,
+                  colheader = c("MOD_AD4TA_0_", "MOD_AD5TA_0_"),
+                  mark = TRUE
+                )
+              }, error = function(e) {
+                res <- expand.grid(
+                  site_id = list_pred_calc_grid[["site_id"]],
+                  time = date_i,
+                  MOD_AD4TA_0_ = NA_real_,
+                  MOD_AD5TA_0_ = NA_real_
+                )
+                names(res)[3:4] <- paste0(names(res)[3:4], sprintf("%05d", r))
+                return(res)
+              })
+              res
+
+            },
+            date_find
+          ) %>%
+          collapse::rowbind(., fill = TRUE)
+        }) %>%
+          Reduce(
+            f = function(d, e) {dplyr::full_join(d, e, by = c("site_id", "time"))},
+            .
+          ) %>%
+          as.data.frame()
+      },
+      pattern = cross(list_pred_calc_grid, list_dates),
+      iteration = "list",
+      resources = targets::tar_resources(
+        crew = targets::tar_resources_crew(controller = "controller_50"),
+        parquet = targets::tar_resources_parquet(compression = "lz4")
+      ),
+      format = "parquet",
+      description = "Calculate MODIS - MCD19_1km features | prediction"
+    )
+    ,
+    ###########################     MODIS - MCD19_5km     ######################
+    targets::tar_target(
+      list_pred_calc_mcd19_5km,
+      command = {
+        search_dir <- file.path(chr_input_dir, "modis_preprocessed", "MCD19A2_5km")
+        date_find <- list_dates
+        
+        lapply(chr_iter_radii, function(r) {
+          Map(
+            f = function(date_i) {
+              date_in <- paste("(", date_i, ")", sep = "")
+              target_file <- list.files(
+                path = search_dir,
+                pattern = paste0(date_in, "\\.tif$"),
+                full.names = TRUE
+              )
+              res <- tryCatch({
+                beethoven::calculate_modis_direct(
+                  file = target_file,
+                  site = list_pred_calc_grid,
+                  site_id = arglist_common[["char_siteid"]],
+                  radius = r,
+                  colheader = c(
+                    "MOD_CSZAN_0_", "MOD_CVZAN_0_", "MOD_RAZAN_0_",
+                    "MOD_SCTAN_0_", "MOD_GLNAN_0_"
+                    ),
+                  mark = TRUE
+                )
+              }, error = function(e) {
+                res <- expand.grid(
+                  site_id = list_pred_calc_grid[["site_id"]],
+                  time = date_i,
+                  MOD_CSZAN_0_ = NA_real_,
+                  MOD_CVZAN_0_ = NA_real_,
+                  MOD_RAZAN_0_ = NA_real_,
+                  MOD_SCTAN_0_ = NA_real_,
+                  MOD_GLNAN_0_ = NA_real_
+                )
+                names(res)[3:7] <- paste0(names(res)[3:7], sprintf("%05d", r))
+                return(res)
+              })
+              res
+
+            },
+            date_find
+          ) %>%
+          collapse::rowbind(., fill = TRUE)
+        }) %>%
+          Reduce(
+            f = function(d, e) {dplyr::full_join(d, e, by = c("site_id", "time"))},
+            .
+          ) %>%
+          as.data.frame()
+      },
+      pattern = cross(list_pred_calc_grid, list_dates),
+      iteration = "list",
+      resources = targets::tar_resources(
+        crew = targets::tar_resources_crew(controller = "controller_50"),
+        parquet = targets::tar_resources_parquet(compression = "lz4")
+      ),
+      format = "parquet",
+      description = "Calculate MODIS - MCD19_5km features | prediction"
+    )
+    ,
+    ###########################       MODIS - MOD09       ######################
+    targets::tar_target(
+      list_pred_calc_mod09,
+      command = {
+        search_dir <- file.path(chr_input_dir, "modis_preprocessed", "MOD09GA")
+        date_find <- list_dates
+        
+        lapply(chr_iter_radii, function(r) {
+          Map(
+            f = function(date_i) {
+              date_in <- paste("(", date_i, ")", sep = "")
+              target_file <- list.files(
+                path = search_dir,
+                pattern = paste0(date_in, "\\.tif$"),
+                full.names = TRUE
+              )
+              res <- tryCatch({
+                beethoven::calculate_modis_direct(
+                  file = target_file,
+                  site = list_pred_calc_grid,
+                  site_id = arglist_common[["char_siteid"]],
+                  radius = r,
+                  colheader = c(
+                    "MOD_SFCRF_1_", "MOD_SFCRF_2_", "MOD_SFCRF_3_", "MOD_SFCRF_4_",
+                    "MOD_SFCRF_5_", "MOD_SFCRF_6_", "MOD_SFCRF_7_"
+                    ),
+                  mark = TRUE
+                )
+              }, error = function(e) {
+                res <- expand.grid(
+                  site_id = list_pred_calc_grid[["site_id"]],
+                  time = date_i,
+                  MOD_SFCRF_1_ = NA_real_,
+                  MOD_SFCRF_2_ = NA_real_,
+                  MOD_SFCRF_3_ = NA_real_,
+                  MOD_SFCRF_4_ = NA_real_,
+                  MOD_SFCRF_5_ = NA_real_,
+                  MOD_SFCRF_6_ = NA_real_,
+                  MOD_SFCRF_7_ = NA_real_
+                )
+                names(res)[3:9] <- paste0(names(res)[3:9], sprintf("%05d", r))
+                return(res)
+              })
+              res
+
+            },
+            date_find
+          ) %>%
+          collapse::rowbind(., fill = TRUE)
+        }) %>%
+          Reduce(
+            f = function(d, e) {dplyr::full_join(d, e, by = c("site_id", "time"))},
+            .
+          ) %>%
+          as.data.frame()
+      },
+      pattern = cross(list_pred_calc_grid, list_dates),
+      iteration = "list",
+      resources = targets::tar_resources(
+        crew = targets::tar_resources_crew(controller = "controller_25"),
+        parquet = targets::tar_resources_parquet(compression = "lz4")
+      ),
+      format = "parquet",
+      description = "Calculate MODIS - MOD09GA features | prediction"
+    )
+    ,
+    ###########################       MODIS - VIIRS       ######################
+    targets::tar_target(
+      list_pred_calc_viirs,
+      command = {
+        search_dir <- file.path(chr_input_dir, "modis_preprocessed", "VIIRS")
+        date_find <- list_dates
+        
+        lapply(chr_iter_radii, function(r) {
+          Map(
+            f = function(date_i) {
+              date_in <- paste("(", date_i, ")", sep = "")
+              target_file <- list.files(
+                path = search_dir,
+                pattern = paste0(date_in, "\\.tif$"),
+                full.names = TRUE
+              )
+              res <- tryCatch({
+                beethoven::calculate_modis_direct(
+                  file = target_file,
+                  site = list_pred_calc_grid,
+                  site_id = arglist_common[["char_siteid"]],
+                  radius = r,
+                  colheader = c(
+                    "MOD_LGHTN_0_"
+                    ),
+                  mark = TRUE
+                )
+              }, error = function(e) {
+                res <- expand.grid(
+                  site_id = list_pred_calc_grid[["site_id"]],
+                  time = date_i,
+                  MOD_LGHTN_0_ = NA_real_
+                )
+                names(res)[3] <- paste0(names(res)[3], sprintf("%05d", r))
+                return(res)
+              })
+              res
+
+            },
+            date_find
+          ) %>%
+          collapse::rowbind(., fill = TRUE)
+        }) %>%
+          Reduce(
+            f = function(d, e) {dplyr::full_join(d, e, by = c("site_id", "time"))},
+            .
+          ) %>%
+          as.data.frame()
+      },
+      pattern = cross(list_pred_calc_grid, list_dates),
+      iteration = "list",
+      resources = targets::tar_resources(
+        crew = targets::tar_resources_crew(controller = "controller_50"),
+        parquet = targets::tar_resources_parquet(compression = "lz4")
+      ),
+      format = "parquet",
+      description = "Calculate MODIS - VIIRS features | prediction"
+    )
+    ,
     ###########################        KOPPEN        ###########################
+    # should be revised
     targets::tar_target(
-      dt_feat_pred_koppen,
+      list_pred_calc_koppen,
       command = {
-        download_koppen
-        data.table::data.table(
+        # download_koppen
           amadeus::calculate_koppen_geiger(
             from = amadeus::process_koppen_geiger(
               path = file.path(
@@ -420,298 +853,427 @@ target_calculate_predict <-
                 "Beck_KG_V1_present_0p0083.tif"
               )
             ),
-            locs = dplyr::bind_rows(list_feat_pred_sites),
-            # NOTE: locs are all AQS sites for computational efficiency
+            locs = list_pred_calc_grid,
             locs_id = "site_id",
             geom = FALSE
-          )
-        )
+          ) %>%
+          as.data.frame()
       },
-      description = "data.table of Koppen Geiger features | pred"
-    ),
+      iteration = "list",
+      pattern = map(list_pred_calc_grid),
+      resources = targets::tar_resources(
+        crew = targets::tar_resources_crew(controller = "controller_50"),
+        parquet = targets::tar_resources_parquet(compression = "lz4")
+      ),
+      format = "parquet",
+      description = "data.table of Koppen Geiger features | prediction grid"
+    )
+    ,
     ###########################      POPULATION      ###########################
     targets::tar_target(
-      list_feat_pred_pop,
+      list_pred_calc_pop,
       command = {
         download_population
-        amadeus::calculate_population(
-          from = amadeus::process_population(
-            path = file.path(
-              chr_input_dir,
-              "population",
-              "data_files",
-              paste0(
-                "gpw_v4_population_density_adjusted_to_",
-                "2015_unwpp_country_totals_rev11_2020_30_sec.tif"
-              )
+        lapply(
+          chr_iter_radii,
+          function(r) {
+            amadeus::calculate_population(
+              from = amadeus::process_population(
+                path = file.path(
+                  chr_input_dir,
+                  "population",
+                  "data_files",
+                  paste0(
+                    "gpw_v4_population_density_adjusted_to_",
+                    "2015_unwpp_country_totals_rev11_2020_30_sec.tif"
+                  )
+                )
+              ),
+              locs = list_pred_calc_grid,
+              locs_id = "site_id",
+              geom = FALSE,
+              radius = r
             )
-          ),
-          locs = list_feat_pred_sites[[1]],
-          locs_id = "site_id",
-          geom = FALSE,
-          radius = chr_iter_radii
-        )
-      },
-      pattern = cross(list_feat_pred_sites, chr_iter_radii),
-      iteration = "list",
-      description = "Calculate population features | pred"
-    ),
-    # targets::tar_target(
-    #   dt_feat_pred_pop,
-    #   command = beethoven::reduce_merge(
-    #     beethoven::reduce_list(list_feat_pred_pop)
-    #   ),
-    #   description = "data.table of population features | pred"
-    # ),
-    ###########################         TRI          ###########################
-    targets::tar_target(
-      list_feat_pred_tri,
-      command = {
-        download_tri
-        beethoven::inject_calculate(
-          covariate = "tri",
-          locs = dplyr::bind_rows(list_feat_pred_sites),
-          # NOTE: locs are all AQS sites for computational efficiency
-          injection = list(
-            domain = df_feat_calc_tri_params$year,
-            domain_name = "year",
-            path = file.path(chr_input_dir, "tri"),
-            variables = c(1, 13, 12, 14, 20, 34, 36, 47, 48, 49),
-            radius = df_feat_calc_tri_params$radius,
-            nthreads = 1,
-            covariate = "tri"
-          )
-        )
-      },
-      iteration = "list",
-      pattern = map(df_feat_calc_tri_params),
-      description = "Calculate TRI features | pred"
-    ),
-    targets::tar_target(
-      list_feat_pred_reduce_tri,
-      command = {
-        list_feat_pred_tri_unnest <- lapply(
-          list_feat_pred_tri,
-          function(x) x[[1]]
-        )
-        chr_tri_radii_index <- sapply(
-          list_feat_pred_tri_unnest,
-          function(x) {
-            any(grepl(sprintf("_%05d", chr_iter_radii), names(x)))
           }
-        )
-        beethoven::reduce_merge(
-          list_feat_pred_tri_unnest[chr_tri_radii_index],
-          by = NULL,
-          all.x = TRUE,
-          all.y = TRUE
-        )
+        ) %>%
+          Reduce(
+            f = function(d, e) dplyr::full_join(d, e, by = c("site_id")),
+            .
+          ) %>%
+          as.data.frame()
       },
+      pattern = map(list_pred_calc_grid),
       iteration = "list",
-      pattern = map(chr_iter_radii),
-      description = "Reduce TRI features based on radii | pred"
-    ),
+      resources = targets::tar_resources(
+        crew = targets::tar_resources_crew(controller = "controller_50"),
+        parquet = targets::tar_resources_parquet(compression = "lz4")
+      ),
+      format = "parquet",
+      description = "Calculate population features | prediction"
+    )
+    ,
+    ###########################         TRI          ###########################
+    # should be revised
     # targets::tar_target(
-    #   dt_feat_pred_tri,
-    #   command = {
-    #     dt_feat_merge_tri <- beethoven::reduce_merge(
-    #       list_feat_pred_reduce_tri,
-    #       by = c("site_id", "time", "lon", "lat", "tri_year"),
-    #       all.x = TRUE,
-    #       all.y = TRUE
-    #     )
-    #     dt_feat_merge_tri[is.na(dt_feat_merge_tri)] <- 0
-    #     dt_feat_pca_tri <- beethoven::post_calc_pca(
-    #       data = dt_feat_merge_tri,
-    #       yvar = NULL,
-    #       num_comp = 5,
-    #       pattern = "FUGITIVE|STACK",
-    #       groups = sprintf("%05d", chr_iter_radii),
-    #       prefix = "TRI",
-    #       kernel = TRUE
-    #     )
-    #   },
-    #   description = "data.table of TRI PCA-reduced features | pred"
-    # ),
+    #   df_feat_calc_tri_params,
+    #   command = expand.grid(
+    #     year = chr_years,
+    #     radius = chr_iter_radii
+    #   ) %>%
+    #     split(seq_len(nrow(.))),
+    #   iteration = "list",
+    #   description = "TRI features"
+    # )
+    # ,
+    targets::tar_target(
+      int_pred_calc_tri_years,
+      command = c(2020),
+      description = "TRI years | download"
+    )
+    ,
+    targets::tar_target(
+      list_pred_calc_tri,
+      command = 
+      {
+        unique_radii <- chr_iter_radii
+
+        grid_rowids <- seq_len(nrow(list_pred_calc_grid))
+        grid_rowidx <- split(
+            grid_rowids,
+            ceiling(grid_rowids / 10000)
+          )
+        
+        # Threefold list comprehension
+        # First is for years (should be rowbinded)
+        lapply(
+          int_pred_calc_tri_years,
+          function(year) {
+            # The second one is for radii: full joined
+            lapply(
+              unique_radii,
+              function(radi) {
+                # The last one is for grid rows: rowbinded
+                lapply(
+                  grid_rowidx,
+                  function(rows) {
+                    grid_sub <- list_pred_calc_grid[rows, ]
+                    res_tri <- tryCatch({
+                      base_tri <-
+                        amadeus::process_tri(
+                          year = year,
+                          path = file.path(chr_input_dir, "tri"),
+                          # variables parameter should be changed properly depending on the vintage
+                          # as of Dec 2024, newly downloaded TRI data has different layout
+                          # compared to the one used in 2023
+                          # add 3 after 20
+                          variables = c(1, 13, 12, 14, 20, 34, 36, 47, 48, 49)
+                        )
+                      res_tri <-
+                        beethoven::calc_tri_mod(
+                          from = base_tri,
+                          locs = list_pred_calc_grid[rows, ],
+                          radius = radi
+                        )
+                      as.data.frame(res_tri)
+                    }, error = function(e) {
+                      res_tri <- data.frame(site_id = grid_sub[["site_id"]], time = year)
+                      return(res_tri)
+                    })
+                    res_tri
+                  }
+                ) %>%
+                collapse::rowbind(., fill = TRUE)
+              }) %>%
+              Reduce(f = function(d, e) dplyr::full_join(d, e, by = c("site_id", "time")), .) 
+        }) %>%
+        collapse::rowbind(., fill = TRUE) %>%
+        as.data.frame()
+
+      }
+      ,
+      pattern = map(list_pred_calc_grid),
+      iteration = "list",
+      resources = targets::tar_resources(
+        crew = targets::tar_resources_crew(controller = "controller_10"),
+        parquet = targets::tar_resources_parquet(compression = "lz4")
+      ),
+      format = "parquet",
+      description = "Calculate TRI features | prediction"
+    )
+    ,
     ###########################         NEI          ###########################
     targets::tar_target(
-      list_feat_pred_nei,
-      command = {
-        download_nei
-        beethoven::inject_calculate(
-          covariate = "nei",
-          locs = list_feat_pred_sites[[1]],
-          injection = list(
-            domain = chr_iter_calc_nei,
-            domain_name = "year",
-            path = file.path(chr_input_dir, "nei", "data_files"),
-            covariate = "nei"
+      chr_iter_calc_nei,
+      command = c(2017, 2020),
+      description = "NEI features | download"
+    )
+    ,
+    targets::tar_target(
+      list_pred_calc_nei,
+      command = 
+      {
+        download_nei <- TRUE
+
+        grid_rowids <- seq_len(nrow(list_pred_calc_grid))
+        grid_rowidx <- split(
+            grid_rowids,
+            ceiling(grid_rowids / 100000)
           )
-        )
-      },
+        
+        # Twofold list comprehension
+        # First is for years (should be rowbinded)
+        lapply(
+          chr_iter_calc_nei,
+          function(year) {
+            # The last one is for grid rows: rowbinded
+            lapply(
+              grid_rowidx,
+              function(rows) {
+                beethoven::inject_calculate(
+                  covariate = "nei",
+                  locs = list_pred_calc_grid[rows, ],
+                  injection = list(
+                    domain = year,
+                    domain_name = "year",
+                    path = file.path(chr_input_dir, "nei", "data_files"),
+                    covariate = "nei"
+                  )
+                ) %>%
+                collapse::rowbind(fill = TRUE)
+              }
+            ) %>%
+            collapse::rowbind(fill = TRUE)
+        }) %>%
+        collapse::rowbind(fill = TRUE) %>%
+        as.data.frame()
+
+      }
+      ,
       iteration = "list",
-      pattern = cross(list_feat_pred_sites, chr_iter_calc_nei),
-      description = "Calculate NEI features | pred"
-    ),
-    # targets::tar_target(
-    #   dt_feat_pred_nei,
-    #   command = beethoven::reduce_list(
-    #     lapply(
-    #       list_feat_pred_nei,
-    #       function(x) data.table::data.table(beethoven::reduce_list(x)[[1]])
-    #     )
-    #   )[[1]],
-    #   description = "data.table of NEI features | pred"
-    # ),
+      pattern = map(list_pred_calc_grid),
+      description = "Calculate NEI features | prediction grid",
+      resources = targets::tar_resources(
+        crew = targets::tar_resources_crew(controller = "controller_15"),
+        parquet = targets::tar_resources_parquet(compression = "lz4")
+      ),
+      format = "parquet"
+    )
+    ,
     ###########################      ECOREGIONS      ###########################
     targets::tar_target(
-      dt_feat_pred_ecoregions,
+      list_pred_calc_ecoregions,
       command = {
-        download_ecoregions
-        data.table::data.table(
-          amadeus::calculate_ecoregion(
-            from = amadeus::process_ecoregion(
-              path = file.path(
-                chr_input_dir,
-                "ecoregions",
-                "data_files",
-                "us_eco_l3_state_boundaries.shp"
-              )
-            ),
-            locs = dplyr::bind_rows(list_feat_pred_sites),
-            # NOTE: locs are all AQS sites for computational efficiency
-            locs_id = "site_id"
-          )
-        )
-      },
-      description = "data.table of Ecoregions features | pred"
-    ),
-    ###########################        GROADS        ###########################
-    targets::tar_target(
-      list_feat_pred_groads,
-      command = {
-        download_groads
-        amadeus::calculate_groads(
-          from = amadeus::process_groads(
+        # download_ecoregions
+        amadeus::calculate_ecoregion(
+          from = amadeus::process_ecoregion(
             path = file.path(
               chr_input_dir,
-              "groads",
+              "ecoregions",
               "data_files",
-              "gROADS-v1-americas.gdb"
+              "us_eco_l3_state_boundaries.shp"
             )
           ),
-          locs = dplyr::bind_rows(list_feat_pred_sites),
+          locs = list_pred_calc_grid,
           # NOTE: locs are all AQS sites for computational efficiency
-          locs_id = "site_id",
-          radius = chr_iter_radii
+          locs_id = "site_id"
         )
       },
       iteration = "list",
-      pattern = map(chr_iter_radii),
-      description = "Calculate gRoads features | pred"
+      pattern = map(list_pred_calc_grid),
+      resources = targets::tar_resources(
+        crew = targets::tar_resources_crew(controller = "controller_25"),
+        parquet = targets::tar_resources_parquet(compression = "lz4")
+      ),
+      format = "parquet",
+      description = "List of Ecoregions features | prediction grid"
     )
-    # targets::tar_target(
-    #   dt_feat_pred_groads,
-    #   command = beethoven::reduce_merge(
-    #     beethoven::reduce_list(list_feat_pred_groads),
-    #     by = c("site_id", "description")
-    #   ),
-    #   description = "data.table of gRoads features | pred"
-    # ),
-    ########################       DATE FEATURES       #########################
-    # targets::tar_target(
-    #   dt_feat_pred_date,
-    #   command = Reduce(
-    #     beethoven::post_calc_autojoin,
-    #     list(
-    #       dt_feat_pred_geos,
-    #       dt_feat_pred_narr,
-    #       dt_feat_pred_nasa
-    #     )
-    #   ),
-    #   description = "data.table of all features | pred"
-    # ),
-    ########################       BASE FEATURES       #########################
-    # targets::tar_target(
-    #   list_feat_pred_base_flat,
-    #   command = lapply(
-    #     list(
-    #       list(dt_feat_pred_hms),
-    #       list(dt_feat_pred_tri),
-    #       list(dt_feat_pred_nei),
-    #       list(dt_feat_pred_ecoregions),
-    #       list(dt_feat_pred_koppen),
-    #       list(dt_feat_pred_pop),
-    #       list(dt_feat_pred_groads)
-    #     ),
-    #     function(x) {
-    #       if (length(x) == 1) {
-    #         x[[1]]
-    #       } else if (
-    #         sum(grepl("light|medium|heavy", sapply(x, \(t) names(t)))) == 3
-    #       ) {
-    #         xr <- lapply(x, \(dt) {
-    #           dta <- data.table::copy(dt)
-    #           dta <- dta[, time := as.character(time)]
-    #           return(dta)
-    #         })
-    #         xrr <- Reduce(
-    #           function(x, y) {
-    #             collapse::join(x, y, on = c("site_id", "time"), how = "full")
-    #           },
-    #           xr
-    #         )
-    #         return(xrr)
-    #       } else {
-    #         collapse::rowbind(x, use.names = TRUE, fill = TRUE)
-    #       }
-    #     }
-    #   ),
-    #   description = "Calculated base feature list (all dt) | pred"
-    # ),
-    # targets::tar_target(
-    #   dt_feat_pred_base,
-    #   command = Reduce(
-    #     beethoven::post_calc_autojoin,
-    #     c(
-    #       list(dt_feat_pred_sites),
-    #       list_feat_pred_base_flat,
-    #       list(dt_feat_pred_gmted),
-    #       list(data.table::data.table(dt_feat_pred_nlcd))
-    #     )
-    #   ),
-    #   description = "Base features with full temporal range | pred"
-    # ),
-    #######################     CUMULATIVE FEATURES      #######################
-    # targets::tar_target(
-    #   dt_feat_pred_design,
-    #   command = beethoven::post_pred_autojoin(
-    #     dt_feat_pred_base,
-    #     dt_feat_pred_date,
-    #     year_start = as.integer(substr(chr_daterange[1], 1, 4)),
-    #     year_end = as.integer(substr(chr_daterange[2], 1, 4))
-    #   ),
-    #   description = "data.table of all features with PM2.5 | pred"
-    # ),
-    # targets::tar_target(
-    #   dt_feat_pred_imputed,
-    #   command = beethoven::impute_all(
-    #     dt_feat_pred_design,
-    #     period = chr_daterange,
-    #     nthreads_dt = 32,
-    #     nthreads_collapse = 32,
-    #     nthreads_imputation = 32
-    #   ),
-    #   description = "Imputed features + lags | pred"
-    # ),
-    # targets::tar_target(
-    #   name = dt_feat_pred_xyt,
-    #   command = data.table::data.table(
-    #     beethoven::attach_xy(
-    #       dt_feat_pred_imputed,
-    #       dplyr::bind_rows(list_feat_pred_sites)
-    #     )
-    #   ),
-    #   description = "Imputed features + AQS sites (outcome and lat/lon) | pred"
-    # )
+    ,
+    ###########################        GROADS        ###########################
+    targets::tar_target(
+      list_pred_calc_groads,
+      command = {
+        download_groads <- TRUE
+
+        grid_rowids <- seq_len(nrow(list_pred_calc_grid))
+        grid_rowidx <- split(
+            grid_rowids,
+            ceiling(grid_rowids / 10000)
+          )
+        
+        # Twofold list comprehension
+        # First is for radii (should be full-joined)
+        lapply(
+          chr_iter_radii,
+          function(radi) {
+            # The last one is for grid rows: rowbinded
+            lapply(
+              grid_rowidx,
+              function(rows) {
+                tryCatch({
+                  amadeus::calculate_groads(
+                    from = amadeus::process_groads(
+                      path = file.path(
+                        chr_input_dir,
+                        "groads",
+                        "data_files",
+                        "gROADS-v1-americas.gdb"
+                      )
+                    ),
+                    locs = list_pred_calc_grid[rows, ],
+                    locs_id = "site_id",
+                    radius = radi
+                  )
+                },
+                error = function(e) {
+                  res <- expand.grid(
+                    site_id = list_pred_calc_grid[["site_id"]],
+                    description = "1980 - 2010",
+                    GRD_TOTAL_0_ = NA_real_,
+                    GRD_DENKM_0_ = NA_real_
+                  )
+                  names(res)[3:4] <- paste0(names(res)[3:4], sprintf("%05d", radi))
+                  return(res)
+                })
+              }
+            ) %>%
+            collapse::rowbind(fill = TRUE)
+          }
+        ) %>%
+        Reduce(function(x, y) dplyr::full_join(x, y, by = c("site_id")), .) %>%
+        as.data.frame()
+
+      },
+      iteration = "list",
+      pattern = map(list_pred_calc_grid),
+      resources = targets::tar_resources(
+        crew = targets::tar_resources_crew(controller = "controller_15"),
+        parquet = targets::tar_resources_parquet(compression = "lz4")
+      ),
+      format = "parquet",
+      description = "Calculate gRoads features | prediction grid"
+    )
+    ,
+    ###########################        SPATIAL BRANCHES FOR PREDICTION       ######################
+    targets::tar_target(
+      list_pred_calc_spatial,
+      command = {
+        Reduce(
+          f = function(d, e) dplyr::full_join(d, e, by = c("site_id")),
+          list(
+          list_pred_calc_nlcd,
+          list_pred_calc_gmted,
+          list_pred_calc_pop,
+          list_pred_calc_koppen,
+          list_pred_calc_ecoregions,
+          list_pred_calc_groads
+          )
+        ) %>%
+        as.data.frame()
+      },
+      pattern = map(
+        list_pred_calc_nlcd,
+        list_pred_calc_gmted,
+        list_pred_calc_pop,
+        list_pred_calc_koppen,
+        list_pred_calc_ecoregions,
+        list_pred_calc_groads
+      ),
+      iteration = "list",
+      format = "parquet",
+      resources = targets::tar_resources(
+        crew = targets::tar_resources_crew(controller = "controller_10"),
+        parquet = targets::tar_resources_parquet(compression = "lz4")
+      ),
+      description = "data.frame of spatial features | prediction"
+    )
+    ,
+    ###########################        SPATIOTEMPORAL BRANCHES FOR PREDICTION       ###########################
+    targets::tar_target(
+      list_pred_calc_spt,
+      command = {
+        Reduce(
+          f = function(d, e) dplyr::full_join(d, e, by = c("site_id", "time")),
+          list_pred_calc_hms,
+          list_pred_calc_mod11,
+          list_pred_calc_mod06,
+          list_pred_calc_mod13,
+          list_pred_calc_mcd19_1km,
+          list_pred_calc_mcd19_5km,
+          list_pred_calc_mod09,
+          list_pred_calc_viirs,
+          list_pred_calc_narr,
+          list_pred_calc_geos_aqc,
+          list_pred_calc_geos_chm
+        ) %>%
+          as.data.frame()
+      },
+      pattern = map(
+        list_pred_calc_hms,
+        list_pred_calc_mod11,
+        list_pred_calc_mod06,
+        list_pred_calc_mod13,
+        list_pred_calc_mcd19_1km,
+        list_pred_calc_mcd19_5km,
+        list_pred_calc_mod09,
+        list_pred_calc_viirs,
+        list_pred_calc_narr,
+        list_pred_calc_geos_aqc,
+        list_pred_calc_geos_chm
+      ),
+      iteration = "list",
+      format = "parquet",
+      resources = targets::tar_resources(
+        crew = targets::tar_resources_crew(controller = "controller_10"),
+        parquet = targets::tar_resources_parquet(compression = "lz4")
+      ),
+      description = "data.frame of spatiotemporal features | prediction"
+    ),
+    #### Reference table for branches to match
+    targets::tar_target(
+      int_pred_calc_lookup_branches,
+      command = {
+        df_branches <-
+          targets::tar_branches(
+            list_pred_calc_geos_aqc
+          )
+        branch_sp <- df_branches[["list_pred_calc_grid"]]
+
+        branch_spindx <- unique(branch_sp)
+        branch_spindx2 <- match(branch_sp, branch_spindx)
+        branch_spindx2
+      },
+      iteration = "list"
+    ),
+    ####################### IRREGULAR INTERVAL BRANCHES FOR PREDICTION ###########################
+    targets::tar_target(
+      list_pred_feat_final,
+      command = {
+
+        join_spec <- dplyr::join_by("site_id", time_temp >= time)
+        list_pred_calc_spt %>%
+          mutate(time_temp = lubridate::year(time)) %>%
+          left_join(
+            list_pred_calc_tri[[int_pred_calc_lookup_branches]],
+            by = join_spec
+          ) %>%
+          left_join(
+            list_pred_calc_nei[[int_pred_calc_lookup_branches]],
+            by = join_spec
+          ) %>%
+          dplyr::select(-time_temp) %>%
+          left_join(
+            list_pred_calc_spatial,
+            by = "site_id"
+          )
+      },
+      pattern = map(list_pred_calc_spt, int_pred_calc_lookup_branches),
+      iteration = "list",
+      # this target is managed as qs to reduce type conversion time
+      format = "qs",
+      resources = targets::tar_resources(
+        crew = targets::tar_resources_crew(controller = "controller_10")
+      ),
+      description = "data.frame of irregular interval features | prediction"
+    )
+
   )

--- a/tests/testthat/test-calculate.R
+++ b/tests/testthat/test-calculate.R
@@ -222,3 +222,227 @@ testthat::test_that("calculate_modis (MOD11A1)", {
   )
 
 })
+
+
+
+testthat::test_that("calculate_modis_direct: correct column renaming, date‐parsing, and mark=TRUE vs FALSE", {
+
+  withr::local_package("terra")
+  withr::local_package("sf")
+  withr::local_package("dplyr")
+  withr::local_package("rlang")
+  withr::local_package("chopin")
+  withr::local_options(list(sf_use_s2 = FALSE))
+
+  # identify MOD11A1 files
+  mod11a1_files <- list.files(
+    testthat::test_path("..", "testdata", "injection", "modis", "mod11a1"),
+    full.names = TRUE
+  )
+  mod11ras <- terra::rast(mod11a1_files, subds="LST_Day_1km")
+  tdir <- tempdir()
+  mod11tif <- file.path(tdir, "mod11a1_h11v05_2021-08-15.tif")
+  terra::writeRaster(
+    mod11ras,
+    filename = mod11tif,
+    overwrite = TRUE,
+    gdal = c("COMPRESS=DEFLATE")
+  )
+
+  site_sf <- sf::st_as_sf(
+    data.frame(
+      lon = -90, lat = 39.5,
+      site_id = "site_id", time = as.Date("2021-08-15")
+    ),
+    coords = c("lon", "lat"),
+    crs = "EPSG:4326"
+  )
+  
+  # Run with mark = TRUE (default)
+  out1 <- calculate_modis_direct(
+    file     = mod11tif,
+    site     = site_sf,
+    site_id  = "site_id",
+    radius   = 1000,           # numeric
+    colheader = "hdR_",
+    mark     = TRUE
+  )
+  
+  # Column names include "hdR_01000"
+  testthat::expect_length(grep("^hdR_01000", names(out1)), 1L)
+  
+  # The returned time column should be a Date extracted from the file name
+  testthat::expect_s3_class(out1$time, "Date")
+  testthat::expect_equal(out1$time, as.Date("2021-08-15"))
+  
+  # The printed column name should have been printed to the console:
+  testthat::expect_identical(colnames(out1)[2], "hdR_01000")
+  
+  # Run again with mark = FALSE
+  out2 <- calculate_modis_direct(
+    file      = mod11tif,
+    site      = site_sf,
+    site_id   = "site_id",
+    radius    = 500,
+    colheader = "FooBar_",
+    mark      = FALSE
+  )
+  
+  # colheader should be exactly "FooBar_" (no padding added).
+  testthat::expect_true(all(grepl("^FooBar_$", names(out2)[grep("FooBar_", names(out2))])))
+  testthat::expect_length(grep("^FooBar_$", names(out2)), 1L)
+  testthat::expect_equal(out2$time, as.Date("2021-08-15"))
+})
+
+
+testthat::test_that("sum_edc_mod: warning on overlapping names and correct numeric sums", {
+
+  withr::local_package("terra")
+  withr::local_package("sf")
+  withr::local_package("dplyr")
+  withr::local_package("rlang")
+  withr::local_package("chopin")
+  withr::local_options(list(sf_use_s2 = FALSE))
+
+  # Build a tiny 'locs' SpatVector with one point
+  sf_locs <- sf::st_as_sf(
+    data.frame(site_id = "S1", X = 100, Y = 100, stringsAsFactors = FALSE),
+    coords = c("X", "Y"), crs = 32614
+  )
+  locs_sp <- terra::vect(sf_locs)
+  locs_sp$site_id <- sf_locs$site_id
+
+  # Build a tiny 'from' SpatVector with two points: (0,0) and (10,0), each with a field "VAL_AIR"
+  df_from <- data.frame(
+    id = c("F1", "F2"),
+    X = c(130, 70),
+    Y = c(140, 60),
+    VAL_AIR = c(10, 10),
+    stringsAsFactors = FALSE
+  )
+  sf_from <- sf::st_as_sf(
+    df_from, coords = c("X", "Y"), crs = 32614)
+  from_sp <- terra::vect(sf_from)
+  
+  # Test the warning about overlapping names:
+  # For example, if both locs and from share a column called “id”:
+  sf_locs2 <- sf::st_as_sf(
+    data.frame(id = "S1", X=0, Y=0, stringsAsFactors = FALSE),
+    coords = c("X","Y"), crs = 32614
+  )
+
+  locs_sp2 <- terra::vect(sf_locs2)
+  locs_sp2$id <- sf_locs2$id
+  # Now "id" overlaps with from_sp's "id", so we expect a warning:
+  testthat::expect_warning(
+    suppressMessages(
+      sum_edc_mod(
+        from            = from_sp,
+        locs            = locs_sp2,
+        locs_id         = "id",
+        sedc_bandwidth  = 100,
+        target_fields   = c("VAL_AIR")
+      )
+    )
+  )
+  
+  # At sedc_bandwidth, each point's attributes are attenuated to
+  # exp(-3)*value, so we expect the sum to be 2 * exp(-3) = 0.099574
+  suppressMessages(
+    out_sedc <- sum_edc_mod(
+      from           = from_sp,
+      locs           = locs_sp,
+      locs_id        = "site_id",
+      sedc_bandwidth = 50,
+      target_fields  = "VAL_AIR"
+    )
+  )
+  
+  # It should return a data.frame (tibble) with one row "site_id"
+  testthat::expect_s3_class(out_sedc, "data.frame")
+  testthat::expect_true("site_id" %in% names(out_sedc))
+  
+  # The column used will be named "VAL_AIR_00005" since sprintf("%05d", 5) → "00005"
+  testthat::expect_true("VAL_AIR" %in% names(out_sedc))
+  
+  computed <- out_sedc$VAL_AIR
+  expected <- 2 * 10 * exp(-3)
+  testthat::expect_equal(computed, expected, tolerance = 1e-6)
+  
+  # Attributes "sedc_bandwidth" and "sedc_threshold" should be attached
+  testthat::expect_equal(attr(out_sedc, "sedc_bandwidth"), 50)
+  testthat::expect_equal(attr(out_sedc, "sedc_threshold"), 100)  # 2 * bandwidth
+  
+})
+
+
+testthat::test_that("calc_tri_mod: correct behavior, whitespace fixed, suffixes appended, and errors", {
+
+  withr::local_package("terra")
+  withr::local_package("sf")
+  withr::local_package("dplyr")
+  withr::local_package("rlang")
+  withr::local_package("chopin")
+  withr::local_options(list(sf_use_s2 = FALSE))
+
+  # Build a tiny 'locs' SpatVector with one point
+  sf_locs <- sf::st_as_sf(
+    data.frame(site_id = "S1", X = 100, Y = 100, stringsAsFactors = FALSE),
+    coords = c("X", "Y"), crs = 32614
+  )
+  locs_sp <- terra::vect(sf_locs)
+  locs_sp$site_id <- sf_locs$site_id
+
+  # Build a minimal 'from' SpatVector with one field "CHEM AIR" (note the space!)
+  #     and set its tri_year attribute to test the time‐roundtrip.
+  df_from <- data.frame(
+    id = c("F1", "F2"),
+    X = c(130, 70),
+    Y = c(140, 60),
+    CHEM_AIR = c(10, 10),
+    stringsAsFactors = FALSE
+  )
+  sf_from <- sf::st_as_sf(
+    df_from, coords = c("X", "Y"), crs = 32614)
+  from_sp <- terra::vect(sf_from)
+
+  # Attach the attribute “tri_year”
+  attr(from_sp, "tri_year") <- 2021L
+  
+  
+  # Use a small radius (e.g. 10) so only the first “from” point at (0,0)
+  #     is within the buffer created by calc_tri_mod()
+  suppressMessages(
+    out_tri <- calc_tri_mod(
+      from    = from_sp,
+      locs    = sf_locs,    # test the branch that converts sf → SpatVector
+      locs_id = "site_id",
+      radius  = 100L
+    )
+  )
+
+  # The “_AIR_” pattern in “CHEM AIR” should have whitespace fixed → "CHEM_AIR"
+  # Then grep("_AIR", names(from2_sp)) picks that field. In sum_edc_mod, a suffix
+  # of sedc_bandwidth ("00010") will be appended. So we expect a column named
+  # "CHEM_AIR_00010" to appear in out_tri.
+  testthat::expect_true(any(grepl("^CHEM_AIR", names(out_tri))))
+  
+  # Check that the “time” column is an integer and matches attr(from,) “tri_year”
+  testthat::expect_true("time" %in% names(out_tri))
+  testthat::expect_type(out_tri$time, "integer")
+  testthat::expect_equal(out_tri$time, 2021L)
+  
+  # If radius is non‐numeric, we expect an error at the very top of calc_tri_mod()
+  testthat::expect_error(
+    suppressMessages(
+      calc_tri_mod(
+        from    = from_sp,
+        locs    = sf_locs,
+        locs_id = "site_id",
+        radius  = "not_numeric"
+      )
+    ),
+    regexp = "radius should be numeric"
+  )
+})
+


### PR DESCRIPTION
### Major changes
- Targets for the prediction grid under extensive refactoring
  - Branching patterns are spatial (via `map(list_pred_calc_grid)`) or spatiotemporal (via `cross(list_pred_calc_grid, list_dates)`), nothing else
  - Final features are also branched; PM2.5 values will be predicted at each spatiotemporal branch, thereby reducing processing time for data concatenation and compression
- `R/calculate.R`: refactored NLCD/TRI calculation functions to match the new branch patterns
  - Tests for the newly added functions
- `data.frame` targets are stored in `parquet` format
  - `DESCRIPTION` file gets `parquet` package, which is not automatically installed upon `targets` installation