### PR TITLE
0.5.1

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: beethoven
 Title: Building an Extensible, rEproducible, Test-driven, Harmonized, Open-source, Versioned, ENsemble model for air quality
-Version: 0.5.0
+Version: 0.5.1
 Authors@R: c(
     person("Kyle", "Messier", , "kyle.messier@nih.gov", role = c("aut", "cre"), comment = c(ORCID = "0000-0001-9508-9623")),
     person("Mitchell", "Manware", role = c("aut", "ctb"), comment = c(ORCID = "0009-0003-6440-6106")),

--- a/inst/targets/targets_baselearner.R
+++ b/inst/targets/targets_baselearner.R
@@ -186,27 +186,40 @@ target_baselearner_lgb <-
       description = "Engine and device | lgb | base learner"
     ),
     targets::tar_target(
-      fit_learner_base_lgb,
+      list_lgb_grid,
       command = {
+        list_rset_train
         df_lgb_grid <- expand.grid(
           mtry = c(150, 239),
           trees = c(250, 445),
           learn_rate = c(0.1, 0.15),
           tree_depth = c(4, 7)
         )
-        beethoven::fit_base_learner(
-          rset = list_rset_train,
-          model = engine_base_lgb,
-          tune_grid_size = df_lgb_grid[
-            sample(nrow(df_lgb_grid), list_base_params_static$tune_grid_size),
-          ],
-          yvar = list_base_params_static$yvar,
-          xvar = list_base_params_static$xvar,
-          drop_vars = list_base_params_static$drop_vars,
-          normalize = list_base_params_static$normalize
-        )
+        df_lgb_grid[
+          sample(nrow(df_lgb_grid), list_base_params_static$tune_grid_size),
+        ]
       },
       pattern = map(list_rset_train),
+      iteration = "list",
+      description = "Hyperparameter grid | lgb | base learner"
+    ),
+    targets::tar_target(
+      int_lgb_iterations,
+      command = seq_along(list_lgb_grid),
+      description = "Hyperparameter grid length | lgb | base learner"
+    ),
+    targets::tar_target(
+      fit_learner_base_lgb,
+      command = beethoven::fit_base_learner(
+        rset = list_rset_train[[int_lgb_iterations]],
+        model = engine_base_lgb,
+        tune_grid_size = list_lgb_grid[[int_lgb_iterations]],
+        yvar = list_base_params_static$yvar,
+        xvar = list_base_params_static$xvar,
+        drop_vars = list_base_params_static$drop_vars,
+        normalize = list_base_params_static$normalize
+      ),
+      pattern = map(int_lgb_iterations),
       iteration = "list",
       resources = targets::tar_resources(
         crew = targets::tar_resources_crew(controller = "controller_cpu")


### PR DESCRIPTION
Calling `sample()` in the `fit_base_learner` function of `fit_base_lgb` was invalidating models after run. Buffering by creating parameter grid in separate target seems to fix, but won't know until full branches are done.